### PR TITLE
Fix: TypeError: BpmnModdle is not a constructor

### DIFF
--- a/lib/AutoLayout.js
+++ b/lib/AutoLayout.js
@@ -19,54 +19,44 @@ function AutoLayout() {
 
 module.exports = AutoLayout;
 
-AutoLayout.prototype.layoutProcess = function(xmlStr, callback) {
+AutoLayout.prototype.layoutProcess = async function(xmlStr) {
   var self = this;
   var moddle = this.moddle;
   var createDiPlane = this.DiFactory.createDiPlane.bind(this.DiFactory);
   var createDiDiagram = this.DiFactory.createDiDiagram.bind(this.DiFactory);
 
-  return new Promise(function(resolve, reject) {
+  try {
+    var { rootElement: moddleWithoutDi } = await moddle.fromXML(xmlStr);
 
-    moddle.fromXML(xmlStr, function(error, moddleWithoutDi) {
-      if (error) {
-        return reject(error);
-      }
-
-      // create new di section
-      var root = moddleWithoutDi.get('rootElements').find(el => el.$type === 'bpmn:Process');
-      var rootDi = createDiPlane({
-        id: 'BPMNPlane_1',
-        bpmnElement: root
-      });
-      var newDiagram = createDiDiagram({
-        id: 'BPMNDiagram_1',
-        plane: rootDi
-      });
-      moddleWithoutDi.diagrams = [newDiagram];
-
-      // build the tree layout
-      self.tree = new Tree();
-      self._addTreeNode(root, root.flowElements);
-      self._buildTreeBreadFirstSearch(root);
-      console.log('tree built');
-      self.tree.UpdateTree();
-      console.log('tree updated');
-
-      // create di
-      self._layoutTreeBreadFirstSearch(root, rootDi);
-      console.log('bpmn element layout complete');
-
-      moddle.toXML(moddleWithoutDi, function(err, result) {
-
-        if (err) {
-          return reject(err);
-        }
-
-        return resolve(result);
-      });
+    // create new di section
+    var root = moddleWithoutDi.get('rootElements').find(el => el.$type === 'bpmn:Process');
+    var rootDi = createDiPlane({
+      id: 'BPMNPlane_1',
+      bpmnElement: root
     });
-  });
+    var newDiagram = createDiDiagram({
+      id: 'BPMNDiagram_1',
+      plane: rootDi
+    });
+    moddleWithoutDi.diagrams = [newDiagram];
 
+    // build the tree layout
+    self.tree = new Tree();
+    self._addTreeNode(root, root.flowElements);
+    self._buildTreeBreadFirstSearch(root);
+    console.log('tree built');
+    self.tree.UpdateTree();
+    console.log('tree updated');
+
+    // create di
+    self._layoutTreeBreadFirstSearch(root, rootDi);
+    console.log('bpmn element layout complete');
+
+    var { xml: result } = await moddle.toXML(moddleWithoutDi);
+    return Promise.resolve(result);
+  } catch (error) {
+    return Promise.reject(error);
+  }
 };
 
 AutoLayout.prototype._buildTreeBreadFirstSearch = function(rootFlowElement) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "bpmn-moddle": "^6.0.0",
+        "bpmn-moddle": "^8.0.1",
         "min-dash": "^3.5.2"
       },
       "devDependencies": {
@@ -296,14 +296,19 @@
       "dev": true
     },
     "node_modules/bpmn-moddle": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-6.0.0.tgz",
-      "integrity": "sha512-/yi7LBT4MFWsv5fmQD7/aeCZC94Ot8onADiJMQkosY2XGN85cVmOpPdmo8FfBu+6gjI9EWUnnUWjjY1SDVLeXw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.0.1.tgz",
+      "integrity": "sha512-mwZcrWhi52+JH5Oq58WwKYcUxQ1ZMiDQuzt1bpqiqEEFFnQLqCgtLwEXQuDXFmAuQPdMAghyPzqdOZQqIQVesw==",
       "dependencies": {
-        "min-dash": "^3.0.0",
-        "moddle": "^5.0.1",
-        "moddle-xml": "^8.0.1"
+        "min-dash": "^4.0.0",
+        "moddle": "^6.0.0",
+        "moddle-xml": "^10.0.0"
       }
+    },
+    "node_modules/bpmn-moddle/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1526,22 +1531,32 @@
       }
     },
     "node_modules/moddle": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-5.0.1.tgz",
-      "integrity": "sha512-RB9NCYxbnQLiY1ZJ8Y61+I8TBEmmyaMr8Tj0+fJHN8Fm6l5NqojDy1s4LNDxq+omvug4gnzERMgT8uwNsADDvw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.2.1.tgz",
+      "integrity": "sha512-rBT4P19k9wKOerFHNJQugw25CK6DK5m4lVZGac7godbWNPsbJgr1K4GJ+pqM1ErbRYxljXCTDgPhJLoDWE4wwQ==",
       "dependencies": {
-        "min-dash": "^3.0.0"
+        "min-dash": "^4.0.0"
       }
     },
     "node_modules/moddle-xml": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-8.0.1.tgz",
-      "integrity": "sha512-aeMpZTFv5Vm5sKXtRRIoXb/4eMssNWjsvb0MNPe7g8x3F2cRmQa2AwT8gnjtlefHwmCxQRbIoP2kutmqfgoKzg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.1.0.tgz",
+      "integrity": "sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==",
       "dependencies": {
-        "min-dash": "^3.0.0",
-        "moddle": "^5.0.1",
-        "saxen": "^8.1.0"
+        "min-dash": "^4.0.0",
+        "moddle": "^6.0.0",
+        "saxen": "^8.1.2"
       }
+    },
+    "node_modules/moddle-xml/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+    },
+    "node_modules/moddle/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -2068,9 +2083,9 @@
       "dev": true
     },
     "node_modules/saxen": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.0.tgz",
-      "integrity": "sha512-34U5SdDUxECB5Jkwbc2mAdxHyGvbfCHv0iHgf+x2jaYLlwsPpju9651Lld9CpFpF4zJsoWcF3Q05blXXNOb/cg=="
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
+      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -2904,13 +2919,20 @@
       "dev": true
     },
     "bpmn-moddle": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-6.0.0.tgz",
-      "integrity": "sha512-/yi7LBT4MFWsv5fmQD7/aeCZC94Ot8onADiJMQkosY2XGN85cVmOpPdmo8FfBu+6gjI9EWUnnUWjjY1SDVLeXw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.0.1.tgz",
+      "integrity": "sha512-mwZcrWhi52+JH5Oq58WwKYcUxQ1ZMiDQuzt1bpqiqEEFFnQLqCgtLwEXQuDXFmAuQPdMAghyPzqdOZQqIQVesw==",
       "requires": {
-        "min-dash": "^3.0.0",
-        "moddle": "^5.0.1",
-        "moddle-xml": "^8.0.1"
+        "min-dash": "^4.0.0",
+        "moddle": "^6.0.0",
+        "moddle-xml": "^10.0.0"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+        }
       }
     },
     "brace-expansion": {
@@ -3880,21 +3902,35 @@
       }
     },
     "moddle": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-5.0.1.tgz",
-      "integrity": "sha512-RB9NCYxbnQLiY1ZJ8Y61+I8TBEmmyaMr8Tj0+fJHN8Fm6l5NqojDy1s4LNDxq+omvug4gnzERMgT8uwNsADDvw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.2.1.tgz",
+      "integrity": "sha512-rBT4P19k9wKOerFHNJQugw25CK6DK5m4lVZGac7godbWNPsbJgr1K4GJ+pqM1ErbRYxljXCTDgPhJLoDWE4wwQ==",
       "requires": {
-        "min-dash": "^3.0.0"
+        "min-dash": "^4.0.0"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+        }
       }
     },
     "moddle-xml": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-8.0.1.tgz",
-      "integrity": "sha512-aeMpZTFv5Vm5sKXtRRIoXb/4eMssNWjsvb0MNPe7g8x3F2cRmQa2AwT8gnjtlefHwmCxQRbIoP2kutmqfgoKzg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.1.0.tgz",
+      "integrity": "sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==",
       "requires": {
-        "min-dash": "^3.0.0",
-        "moddle": "^5.0.1",
-        "saxen": "^8.1.0"
+        "min-dash": "^4.0.0",
+        "moddle": "^6.0.0",
+        "saxen": "^8.1.2"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+        }
       }
     },
     "ms": {
@@ -4307,9 +4343,9 @@
       "dev": true
     },
     "saxen": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.0.tgz",
-      "integrity": "sha512-34U5SdDUxECB5Jkwbc2mAdxHyGvbfCHv0iHgf+x2jaYLlwsPpju9651Lld9CpFpF4zJsoWcF3Q05blXXNOb/cg=="
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
+      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw=="
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bpmn-io/bpmn-auto-layout#readme",
   "dependencies": {
-    "bpmn-moddle": "^6.0.0",
+    "bpmn-moddle": "^8.0.1",
     "min-dash": "^3.5.2"
   },
   "devDependencies": {

--- a/test/AutoLayoutSpec.js
+++ b/test/AutoLayoutSpec.js
@@ -10,26 +10,16 @@ async function cleanDI(diagramXML) {
 
   const moddle = new BpmnModdle();
 
-  return new Promise(function(resolve, reject) {
+  try {
+    const { rootElement: definitions } = await moddle.fromXML(diagramXML);
+    definitions.diagrams = [];
 
-    moddle.fromXML(diagramXML, function(err, definitions) {
+    const { xml } = await moddle.toXML(definitions);
 
-      if (err) {
-        return reject(err);
-      }
-
-      definitions.diagrams = [];
-
-      moddle.toXML(definitions, function(err, xml) {
-
-        if (err) {
-          return reject(err);
-        }
-
-        return resolve(xml);
-      });
-    });
-  });
+    return Promise.resolve(xml);
+  } catch (error) {
+    return Promise.reject(error);
+  }
 }
 
 async function test(diagramName) {
@@ -55,11 +45,6 @@ describe('bpmn-auto-layout', function() {
 
     it('process-diagram', async function() {
       await test('process-diagram.bpmn');
-    });
-
-
-    it('parallel flows', function() {
-
     });
 
 


### PR DESCRIPTION
## Description:
This PR updates [`bpmn-moddle`](https://github.com/bpmn-io/bpmn-moddle) package to the latest version. And refactors the `cleanDI` function at the test file and `AutoLayout`'s `layoutProcess` method.

## Related issues:
* https://github.com/bpmn-io/bpmn-auto-layout/issues/18
* https://github.com/bpmn-io/bpmn-auto-layout/issues/22
