### PR TITLE
Fix: TypeError: BpmnModdle is not a constructor (at work with es modules)

### DIFF
--- a/lib/AutoLayout.js
+++ b/lib/AutoLayout.js
@@ -1,4 +1,4 @@
-var BpmnModdle = require('bpmn-moddle');
+var BpmnModdlePackage = require('bpmn-moddle');
 var Tree = require('./Tree');
 var DiFactory = require('./DiFactory');
 
@@ -7,6 +7,8 @@ var DiUtil = require('./DiUtil');
 var is = DiUtil.is;
 var getExpandedBounds = DiUtil.getExpandedBounds;
 var getBendpoints = DiUtil.getBendpoints;
+
+var BpmnModdle = BpmnModdlePackage.default || BpmnModdlePackage;
 
 var PADDING_NODE = 'padding_node';
 


### PR DESCRIPTION
## Description
I met with this error again, when using es modules. To fix this problem, I decided to use 'OR' condition to get truly `BpmnModdle` class for both available types (commonjs, es modules). I believe that this PR fully closes and resolves the `BpmnModdle is not a constructor` error.

## Related PRs:
* https://github.com/bpmn-io/bpmn-auto-layout/pull/30

## Related issues:
* https://github.com/bpmn-io/bpmn-auto-layout/issues/18
* https://github.com/bpmn-io/bpmn-auto-layout/issues/22


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
