### PR TITLE
Use the .cjs extension for CommonJS export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "exports": {
     ".": {
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This PR makes it so that CommonJS exports use the `.cjs` extension, allowing the module to be imported into a Node app using CommonJS.

I've verified that after running `npm run build`, the `dist` folder contains an `index.cjs` and an `index.cjs.map` file.

Closes #39