### PR TITLE
fix: extra spaces after element

### DIFF
--- a/lib/handler/attachersHandler.js
+++ b/lib/handler/attachersHandler.js
@@ -85,11 +85,6 @@ function insertIntoGrid(newElement, host, grid) {
     grid.createRow(row);
   }
 
-  // Host has element directly after, add space
-  if (grid.get(row, col + 1)) {
-    grid.addAfter(host, null);
-  }
-
   grid.add(newElement, [ row + 1, col + 1 ]);
 }
 

--- a/test/snapshots/boundary-event.simple.bpmn
+++ b/test/snapshots/boundary-event.simple.bpmn
@@ -33,7 +33,7 @@
         <dc:Bounds x="207" y="92" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1w296ux_di" bpmnElement="Event_1w296ux">
-        <dc:Bounds x="507" y="52" width="36" height="36" />
+        <dc:Bounds x="357" y="52" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_01xq0ps_di" bpmnElement="Event_01xq0ps">
         <dc:Bounds x="357" y="192" width="36" height="36" />
@@ -44,7 +44,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1guv5l8_di" bpmnElement="Flow_1guv5l8">
         <di:waypoint x="275" y="70" />
-        <di:waypoint x="507" y="70" />
+        <di:waypoint x="357" y="70" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_06n2ega_di" bpmnElement="Flow_06n2ega">
         <di:waypoint x="225" y="128" />


### PR DESCRIPTION
Closes #47

### Proposed Changes
![image](https://github.com/user-attachments/assets/f6d769f7-168d-4a09-975c-8a4333941340)

- [x] No extra spaces after element

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
