### PR TITLE
48 link events

### DIFF
--- a/lib/Layouter.js
+++ b/lib/Layouter.js
@@ -27,8 +27,10 @@ export class Layouter {
 
     const root = this.getProcess();
 
-    this.cleanDi();
-    this.handlePlane(root);
+    if (root) {
+      this.cleanDi();
+      this.handlePlane(root);
+    }
 
     return (await this.moddle.toXML(this.diagram, { format: true })).xml;
   }

--- a/lib/Layouter.js
+++ b/lib/Layouter.js
@@ -67,12 +67,14 @@ export class Layouter {
     });
 
     // Depth-first-search
-    const stack = [ ...startingElements ];
+    const stack = [ ...startingElements.reverse() ];
     const visited = new Set();
 
     startingElements.forEach(el => {
-      grid.add(el);
-      visited.add(el);
+      if (is(el, 'bpmn:StartEvent')) {
+        grid.add(el);
+        visited.add(el);
+      }
     });
 
     while (stack.length > 0) {

--- a/lib/handler/incomingHandler.js
+++ b/lib/handler/incomingHandler.js
@@ -1,0 +1,25 @@
+export default {
+  'addToGrid': ({ element, grid, visited }) => {
+    const nextElements = [];
+
+    // Handle incoming paths
+    const incoming = (element.incoming || [])
+      .map(out => out.sourceRef)
+      .filter(el => el);
+
+    if (incoming.length > 1) {
+
+      incoming.forEach((nextElement, index, arr) => {
+        if (visited.has(nextElement)) {
+          return;
+        }
+
+        grid.addBelow(arr[index - 1], nextElement);
+
+        nextElements.unshift(nextElement);
+        visited.add(nextElement);
+      });
+    }
+    return nextElements;
+  },
+};

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -1,5 +1,6 @@
 import { default as attacherHandler } from './attachersHandler.js';
 import { default as elementHandler } from './elementHandler.js';
 import { default as outgoingHandler } from './outgoingHandler.js';
+import { default as incomingHandler } from './incomingHandler.js';
 
-export const handlers = [ elementHandler, outgoingHandler, attacherHandler ];
+export const handlers = [ elementHandler, outgoingHandler, incomingHandler, attacherHandler ];

--- a/lib/handler/outgoingHandler.js
+++ b/lib/handler/outgoingHandler.js
@@ -1,4 +1,5 @@
 import { connectElements } from '../utils/layoutUtil.js';
+import { is } from '../di/DiUtil.js';
 
 export default {
   'addToGrid': ({ element, grid, visited }) => {
@@ -17,6 +18,9 @@ export default {
 
       if (!previousElement) {
         grid.addAfter(element, nextElement);
+      }
+      else if (is(element, 'bpmn:ExclusiveGateway')) {
+        grid.addAfter(previousElement, nextElement);
       }
       else {
         grid.addBelow(arr[index - 1], nextElement);

--- a/test/fixtures/empty-definition.bpmn
+++ b/test/fixtures/empty-definition.bpmn
@@ -1,0 +1,2 @@
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_13fbzpq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.16.2">
+</bpmn:definitions>


### PR DESCRIPTION
Closes #48 

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Issue 1: Multiple start events  
![image](https://github.com/user-attachments/assets/ed30e028-718c-4c10-81a4-9f0f45e67980)

Resolution: 
![image](https://github.com/user-attachments/assets/89dd6f8b-39fb-4e0a-8eee-87d46f7270d1)


Issue 2: Multiple gateway elements connected must be in single row
![image](https://github.com/user-attachments/assets/d4420985-1426-4ea2-8571-c2a9d7a0f202)

Resolution: 
![image](https://github.com/user-attachments/assets/1250b080-6efa-40c9-bcba-dd139b876392)


### Changes Implemented:

- Modified the logic to only include elements of type bpmn:StartEvent when processing starting elements.
- Added an incomingHandler to check whether an element has more than one incoming edge
-    If the element has multiple incoming edges, the handler now sends the second one to the grid below.
- Updated the handling of gateways to ensure they are displayed on a single row in the grid.

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
