### PR TITLE
48 link events

### DIFF
--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -1,6 +1,40 @@
 export class Grid {
   constructor() {
     this.grid = [];
+    this.highestRow = 0;
+    this.highestColumn = 0;
+    this.smallestColumn = 0;
+  }
+
+  updateHighest(position) {
+    const [ row, col ] = position;
+
+    if (row > this.highestRow) {
+      this.highestRow = row;
+    }
+    if (col > this.highestColumn) {
+      this.highestColumn = col;
+    }
+    if (col < this.smallestColumn) {
+      this.smallestColumn = col;
+    }
+  }
+
+  ensureRow(row) {
+    if (row > this.highestRow) {
+      for (let rowIndex = this.highestRow + 1; rowIndex <= row; rowIndex++) {
+        console.log(rowIndex);
+        this.grid[rowIndex] = [];
+      }
+    }
+  }
+
+  checkPosition(position) {
+    console.log(position);
+    const [ row, col ] = position;
+    if (this.grid[row][col]) {
+      throw new Error('Grid is occupied and we could not find a place - this should not happen');
+    }
   }
 
   add(element, position) {
@@ -14,15 +48,11 @@ export class Grid {
       this._addStart(element);
     }
 
-    if (!this.grid[row]) {
-      this.grid[row] = [];
-    }
-
-    if (this.grid[row][col]) {
-      throw new Error('Grid is occupied please ensure the place you insert at is not occupied');
-    }
+    this.ensureRow(row);
+    this.checkPosition(position);
 
     this.grid[row][col] = element;
+    this.updateHighest(position);
   }
 
   createRow(afterIndex) {
@@ -34,51 +64,149 @@ export class Grid {
   }
 
   _addStart(element) {
-    this.grid.push([ element ]);
+    this.grid.push([ ...new Array(10).fill(null), element ]);
+    this.highestRow = this.grid.length - 1;
   }
 
-  addAfter(element, newElement) {
-    if (!element) {
-      this._addStart(newElement);
+  addToNextEmptyColumn(position, newElement) {
+    const [ row, col ] = position;
+    let emptyCol = col + 1;
+
+    if (row <= this.highestRow) {
+      while (this.getElementsInRange({ row: row, col: emptyCol }, { row: this.highestRow, col: emptyCol }).length !== 0) {
+        emptyCol += 1;
+      }
     }
 
-    const [ row, col ] = this.find(element);
-    this.grid[row].splice(col + 1, 0, newElement);
+    this.ensureRow(row);
+    this.checkPosition([ row, emptyCol ]);
+
+    console.log([ row, emptyCol ]);
+    this.grid[row][emptyCol] = newElement;
+    this.updateHighest([ row, emptyCol ]);
   }
 
-  addBelow(element, newElement) {
-    if (!element) {
-      this._addStart(newElement);
+  addToNextEmptyRowAndColumn(position, newElement, rowOffset) {
+    const [ row, col ] = position;
+    let emptyRow = row + rowOffset;
+    let emptyCol = col + 1;
+
+    if (emptyCol <= this.highestColumn) {
+      while (this.getElementsInRange({ row: emptyRow, col: emptyCol }, { row: emptyRow, col: this.highestColumn }).length !== 0) {
+        console.log(emptyRow);
+        emptyRow += 1;
+      }
+    }
+    if (emptyRow <= this.highestRow) {
+      while (this.getElementsInRange({ row: emptyRow, col: emptyCol }, { row: this.highestRow, col: emptyCol }).length !== 0) {
+        emptyCol += 1;
+      }
     }
 
-    const [ row, col ] = this.find(element);
+    this.ensureRow(emptyRow);
+    this.checkPosition([ emptyRow, emptyCol ]);
 
-    // We are at the bottom of the current grid - add empty row below
-    if (!this.grid[row + 1]) {
-      this.grid[row + 1] = [];
+    console.log([ emptyRow, emptyCol ]);
+    this.grid[emptyRow][emptyCol] = newElement;
+    this.updateHighest([ emptyRow, emptyCol ]);
+  }
+
+  addToNextEmptyRow(position, newElement, rowOffset) {
+    const [ row, col ] = position;
+    let emptyRow = row + rowOffset;
+
+    if (col + 1 <= this.highestColumn) {
+      while (this.getElementsInRange({ row: emptyRow, col: col + 1 }, { row: emptyRow, col: this.highestColumn }).length !== 0) {
+        console.log(emptyRow);
+        emptyRow += 1;
+      }
     }
 
-    // The element below is already occupied - insert new row
-    if (this.grid[row + 1][col]) {
-      this.grid.splice(row + 1, 0, []);
+    this.ensureRow(emptyRow);
+    this.checkPosition([ emptyRow, col + 1 ]);
+
+    console.log([ emptyRow, col + 1 ]);
+    this.grid[emptyRow][col + 1] = newElement;
+    this.updateHighest([ emptyRow, col + 1 ]);
+  }
+
+
+  addToPreviousEmptyColumn(position, newElement) {
+    const [ row, col ] = position;
+    let emptyCol = col - 1;
+
+    if (row <= this.highestRow) {
+      while (this.getElementsInRange({ row: row, col: emptyCol }, { row: this.highestRow, col: emptyCol }).length !== 0) {
+        emptyCol -= 1;
+      }
     }
 
-    if (this.grid[row + 1][col]) {
-      throw new Error('Grid is occupied and we could not find a place - this should not happen');
+    this.ensureRow(row);
+    this.checkPosition([ row, emptyCol ]);
+
+    console.log([ row, emptyCol ]);
+    this.grid[row][emptyCol] = newElement;
+    this.updateHighest([ row, emptyCol ]);
+  }
+
+  addToPreviousEmptyRowAndColumn(position, newElement, rowOffset) {
+    const [ row, col ] = position;
+    let emptyRow = row + rowOffset;
+    let emptyCol = col - 1;
+
+    if (emptyCol >= this.smallestColumn) {
+      while (this.getElementsInRange({ row: emptyRow, col: emptyCol }, { row: emptyRow, col: this.smallestColumn }).length !== 0) {
+        console.log(emptyRow);
+        emptyRow += 1;
+      }
+    }
+    if (emptyRow <= this.highestRow) {
+      while (this.getElementsInRange({ row: emptyRow, col: emptyCol }, { row: this.highestRow, col: emptyCol }).length !== 0) {
+        emptyCol -= 1;
+      }
     }
 
-    this.grid[row + 1][col] = newElement;
+    this.ensureRow(emptyRow);
+    this.checkPosition([ emptyRow, emptyCol ]);
+
+    console.log([ emptyRow, emptyCol ]);
+    this.grid[emptyRow][emptyCol] = newElement;
+    this.updateHighest([ emptyRow, emptyCol ]);
+  }
+
+  addToPreviousEmptyRow(position, newElement, rowOffset) {
+    console.log('previous empty row');
+    const [ row, col ] = position;
+    let emptyRow = row + rowOffset;
+
+    if (col - 1 >= this.smallestColumn) {
+      while (this.getElementsInRange({ row: emptyRow, col: col - 1 }, { row: emptyRow, col: this.smallestColumn }).length !== 0) {
+        console.log(emptyRow);
+        emptyRow += 1;
+      }
+    }
+
+    this.ensureRow(emptyRow);
+    this.checkPosition([ emptyRow, col - 1 ]);
+
+    console.log([ emptyRow, col - 1 ]);
+    this.grid[emptyRow][col - 1] = newElement;
+    this.updateHighest([ emptyRow, col - 1 ]);
   }
 
   find(element) {
+    let found = false;
     let row, col;
     row = this.grid.findIndex((row) => {
       col = row.findIndex((el) => {
+        found = el === element;
         return el === element;
       });
 
-      return col !== -1;
+      return found;
     });
+    console.log('found here');
+    console.log([ row, col ]);
 
     return [ row, col ];
   }

--- a/lib/Layouter.js
+++ b/lib/Layouter.js
@@ -1,5 +1,5 @@
 import BPMNModdle from 'bpmn-moddle';
-import { isBoundaryEvent, isConnection } from './utils/elementUtils.js';
+import { isBoundaryEvent, isConnection, sortByType, sortByPosition } from './utils/elementUtils.js';
 import { Grid } from './Grid.js';
 import { DiFactory } from './di/DiFactory.js';
 import { is } from './di/DiUtil.js';
@@ -45,16 +45,12 @@ export class Layouter {
   createGridLayout(root) {
     const grid = new Grid();
 
-    const flowElements = root.flowElements || [];
+    const flowElements = root.flowElements;
 
-    // check for empty process/subprocess
-    if (!flowElements) {
-      return grid;
-    }
-
-    const startingElements = flowElements.filter(el => {
+    // Find starting elements and sort type bpmn:StartEvent to the front
+    const startingElements = sortByType(flowElements.filter(el => {
       return !isConnection(el) && !isBoundaryEvent(el) && (!el.incoming || el.length === 0);
-    });
+    }), 'bpmn:StartEvent');
 
     const boundaryEvents = flowElements.filter(el => isBoundaryEvent(el));
     boundaryEvents.forEach(boundaryEvent => {
@@ -64,29 +60,45 @@ export class Layouter {
       attachedTask.attachers = attachers;
     });
 
-    // Depth-first-search
-    const stack = [ ...startingElements ];
+    // Depth-first-search / reverse startingElements for stack to start with bpmn:StartEvent elements
+    const stack = [ startingElements[0] ];
     const visited = new Set();
 
+    // skipped is used for elements that need to be revisited when the stack is empty
+    const skipped = [];
+
     startingElements.forEach(el => {
-      grid.add(el);
-      visited.add(el);
-    });
-
-    while (stack.length > 0) {
-      const currentElement = stack.pop();
-
-      if (is(currentElement, 'bpmn:SubProcess')) {
-        this.handlePlane(currentElement);
+      if (!visited.has(el)) {
+        grid.add(el);
+        visited.add(el);
+        stack.push(el);
       }
 
-      const nextElements = this.handle('addToGrid', { element: currentElement, grid, visited });
+      while (stack.length > 0 || skipped.length > 0) {
+        if (stack.length > 0) {
+          const currentElement = stack.pop();
 
-      nextElements.flat().forEach(el => {
-        stack.push(el);
-        visited.add(el);
-      });
-    }
+          if (is(currentElement, 'bpmn:SubProcess')) {
+            this.handlePlane(currentElement);
+          }
+
+          const nextElements = this.handle('addToGrid', { element: currentElement, grid, stack, visited, skipped, force: false });
+
+          nextElements.flat().forEach(el => {
+            stack.push(el);
+          });
+        }
+
+        if (stack.length === 0 && skipped.length !== 0) {
+          console.log('run from skipped');
+          const currentElement = sortByPosition(grid, skipped).pop();
+          const nextElements = this.handle('addToGrid', { element: currentElement, grid, stack, visited, skipped, force: true });
+          nextElements.flat().forEach(el => {
+            stack.push(el);
+          });
+        }
+      }
+    });
 
     return grid;
   }

--- a/lib/handler/attachersHandler.js
+++ b/lib/handler/attachersHandler.js
@@ -6,15 +6,22 @@ import {
   getDockingPoint,
   getMid
 } from '../utils/layoutUtil.js';
+import { sortByInstance, findMergingStartingPosition } from '../utils/elementUtils.js';
 
 export default {
-  'addToGrid': ({ element, grid, visited }) => {
+  'addToGrid': ({ element, grid, stack, visited, skipped, force }) => {
     const nextElements = [];
 
-    const attachedOutgoing = (element.attachers || [])
+    console.log('visiting');
+    console.log(element);
+
+    let attachedOutgoing = (element.attachers || [])
       .map(att => att.outgoing.reverse())
       .flat()
       .map(out => out.targetRef);
+
+    attachedOutgoing = sortByInstance(attachedOutgoing, 'bpmn:Gateway');
+    attachedOutgoing = sortByInstance(attachedOutgoing, 'bpmn:Task');
 
     // handle boundary events
     attachedOutgoing.forEach((nextElement, index, arr) => {
@@ -22,9 +29,43 @@ export default {
         return;
       }
 
-      // Add below and to the right of the element
-      insertIntoGrid(nextElement, element, grid);
+      const nextIncoming = (nextElement.incoming || [])
+        .map(out => out.sourceRef)
+        .filter(el => el);
+
+
+      const nextOutgoing = (nextElement.outgoing || [])
+        .map(out => out.targetRef)
+        .filter(el => el);
+
+      const isMerging = nextIncoming.length > 1;
+      const skipThis = isMerging && !nextIncoming.every(el => visited.has(el));
+
+      const isSplitting = nextOutgoing.length > 1;
+
+      if ((skipThis || isSplitting) && !force && !stack.indexOf(element) !== -1 && !skipped.indexOf(element) !== -1) {
+        console.log('skip');
+        skipped.push(element);
+        return;
+      }
+
+      console.log('adding');
+      console.log(nextElement);
+
+      if (isMerging) {
+        console.log('to row');
+        grid.addToNextEmptyRowAndColumn(findMergingStartingPosition(grid, nextIncoming), nextElement, 0);
+      } else if (isSplitting) {
+        console.log('to column');
+        grid.addToNextEmptyColumn(grid.find(element), nextElement);
+      } else {
+        console.log('after');
+        grid.addToNextEmptyRowAndColumn(grid.find(element), nextElement, 1);
+      }
+
       nextElements.push(nextElement);
+      visited.add(nextElement);
+      force = false;
     });
 
     return nextElements;
@@ -77,21 +118,21 @@ export default {
 };
 
 
-function insertIntoGrid(newElement, host, grid) {
-  const [ row, col ] = grid.find(host);
+// function insertIntoGrid(newElement, host, grid) {
+//   const [ row, col ] = grid.find(host);
 
-  // Grid is occupied
-  if (grid.get(row + 1, col) || grid.get(row + 1, col + 1)) {
-    grid.createRow(row);
-  }
+//   // Grid is occupied
+//   if (grid.get(row + 1, col) || grid.get(row + 1, col + 1)) {
+//     grid.createRow(row);
+//   }
 
-  // Host has element directly after, add space
-  if (grid.get(row, col + 1)) {
-    grid.addAfter(host, null);
-  }
+//   // Host has element directly after, add space
+//   // if (grid.get(row, col + 1)) {
+//   //   grid.addAfter(host, null);
+//   // }
 
-  grid.add(newElement, [ row + 1, col + 1 ]);
-}
+//   grid.add(newElement, [ row + 1, col + 1 ]);
+// }
 
 function ensureExitBottom(source, waypoints, [ row, col ]) {
 

--- a/lib/handler/outgoingHandler.js
+++ b/lib/handler/outgoingHandler.js
@@ -1,34 +1,135 @@
 import { connectElements } from '../utils/layoutUtil.js';
+import { sortByInstance, findMergingStartingPosition, findSplittingStartingPosition } from '../utils/elementUtils.js';
 
 export default {
-  'addToGrid': ({ element, grid, visited }) => {
+  'addToGrid': ({ element, grid, stack, visited, skipped, force }) => {
     const nextElements = [];
 
+    console.log('visiting');
+    console.log(element);
+
     // Handle outgoing paths
-    const outgoing = (element.outgoing || [])
+    let outgoing = (element.outgoing || [])
       .map(out => out.targetRef)
       .filter(el => el);
 
-    let previousElement = null;
+    outgoing = sortByInstance(outgoing, 'bpmn:Task');
+    outgoing = sortByInstance(outgoing, 'bpmn:Gateway');
+    outgoing = sortByInstance(outgoing, 'bpmn:EndEvent');
+
     outgoing.forEach((nextElement, index, arr) => {
       if (visited.has(nextElement)) {
         return;
       }
 
-      if (!previousElement) {
-        grid.addAfter(element, nextElement);
-      }
-      else {
-        grid.addBelow(arr[index - 1], nextElement);
+      const nextIncoming = (nextElement.incoming || [])
+        .map(out => out.sourceRef)
+        .filter(el => el);
+
+
+      const nextOutgoing = (nextElement.outgoing || [])
+        .map(out => out.targetRef)
+        .filter(el => el);
+
+      const isMerging = nextIncoming.length > 1;
+      const skipThis = isMerging && !nextIncoming.every(el => visited.has(el));
+
+      const isSplitting = nextOutgoing.length > 1;
+
+      if ((skipThis || isSplitting) && !force && !stack.indexOf(element) !== -1 && !skipped.indexOf(element) !== -1) {
+        skipped.push(element);
+        return;
       }
 
-      // Is self-looping
-      if (nextElement !== element) {
-        previousElement = nextElement;
+      console.log('adding');
+      console.log(nextElement);
+
+      if (isMerging) {
+        console.log('to row');
+        grid.addToNextEmptyRowAndColumn(findMergingStartingPosition(grid, nextIncoming), nextElement, 0);
+      } else if (isSplitting) {
+        console.log('to column');
+        grid.addToNextEmptyColumn(grid.find(element), nextElement);
+      } else {
+        console.log('after');
+        console.log(index);
+        grid.addToNextEmptyRow(grid.find(element), nextElement, index);
       }
 
       nextElements.unshift(nextElement);
       visited.add(nextElement);
+      force = false;
+    });
+
+    // Handle incoming paths
+    let incoming = (element.incoming || [])
+      .map(out =>
+      {
+        if (out.sourceRef.$type == 'bpmn:BoundaryEvent') {
+          return out.sourceRef.attachedToRef;
+        } else {
+          return out.sourceRef;
+        }
+      })
+      .filter(el => el);
+
+    incoming = sortByInstance(incoming, 'bpmn:Task');
+    incoming = sortByInstance(incoming, 'bpmn:Gateway');
+
+    incoming.forEach((nextElement, index, arr) => {
+      if (visited.has(nextElement)) {
+        return;
+      }
+
+      // const nextIncoming = (nextElement.incoming || [])
+      //   .map(out => out.sourceRef)
+      //   .filter(el => el);
+
+
+      let nextOutgoing = [
+        ...(nextElement.outgoing || []).map(out => out.targetRef)
+          .filter(el => el),
+        ...(nextElement.attachers || [])
+          .map(att => att.outgoing.reverse())
+          .flat()
+          .map(out => out.targetRef)
+      ];
+
+      console.log('nextOutgoing');
+      nextOutgoing.forEach(el => console.log(el));
+
+      const isCurrentMerging = incoming.length > 1;
+      const isSplitting = nextOutgoing.length > 1;
+
+      const skipThis = isSplitting && !nextOutgoing.every(el => visited.has(el));
+
+      if ((skipThis || isCurrentMerging) && !force && !stack.indexOf(element) !== -1 && !skipped.indexOf(element) !== -1) {
+        console.log('skip this');
+        console.log(isCurrentMerging);
+        console.log(isSplitting);
+        console.log(!nextOutgoing.every(el => visited.has(el)));
+        skipped.push(element);
+        return;
+      }
+
+      console.log('adding');
+      console.log(nextElement);
+
+      if (isSplitting) {
+        console.log('to column');
+        grid.addToPreviousEmptyColumn(findSplittingStartingPosition(grid, nextOutgoing), nextElement);
+      } else if (isCurrentMerging) {
+        console.log('to row');
+        grid.addToPreviousEmptyRow(grid.find(element), nextElement, 0);
+      } else {
+        console.log('before');
+        console.log(index);
+        grid.addToPreviousEmptyRow(grid.find(element), nextElement, index);
+      }
+
+      nextElements.unshift(nextElement);
+      visited.add(nextElement);
+      force = false;
     });
 
     return nextElements;
@@ -38,6 +139,7 @@ export default {
 
     return outgoing.map(out => {
       const target = out.targetRef;
+      console.log(target);
       const waypoints = connectElements(element, target, layoutGrid);
 
       const connectionDi = diFactory.createDiEdge(out, waypoints, {

--- a/lib/utils/elementUtils.js
+++ b/lib/utils/elementUtils.js
@@ -5,3 +5,91 @@ export function isConnection(element) {
 export function isBoundaryEvent(element) {
   return !!element.attachedToRef;
 }
+
+export function sortByType(array, type) {
+
+  // A custom sort function that sorts elements with $type equal to "type" to the front
+  return array.sort((a, b) => {
+    if (a.$type == type && b.$type != type) {
+      return -1;
+    }
+    if (a.$type != type && b.$type == type) {
+      return 1;
+    }
+    if ((a.incoming || []).length > 1 && (b.incoming || []).length === 1) {
+      return 1;
+    }
+    if ((a.incoming || []).length === 1 && (b.incoming || []).length > 1) {
+      return -1;
+    }
+    return 0;
+  });
+}
+
+export function sortByInstance(array, instance) {
+
+  // A custom sort function that sorts elements with $instanceOf equal to "instance" to the front
+  return array.sort((a, b) => {
+    if (a.$instanceOf(instance) && !b.$instanceOf(instance)) {
+      return -1;
+    }
+    if (!a.$instanceOf(instance) && b.$instanceOf(instance)) {
+      return 1;
+    }
+    if ((a.incoming || []).length > 1 && (b.incoming || []).length === 1) {
+      return 1;
+    }
+    if ((a.incoming || []).length === 1 && (b.incoming || []).length > 1) {
+      return -1;
+    }
+    return 0;
+  });
+}
+
+export function sortByPosition(grid, array) {
+  return array.sort((a, b) => {
+    const aPosition = grid.find(a);
+    const bPosition = grid.find(b);
+    if (aPosition[1] !== bPosition[1]) {
+      return Math.sign(aPosition[1] - bPosition[1]);
+    } else {
+      return Math.sign(aPosition[0] - bPosition[0]);
+    }
+  });
+}
+
+export function findMergingStartingPosition(grid, elements) {
+  console.log('findMerging');
+
+  let smallestRow = -1;
+  let highestColumn = -1;
+  elements.forEach(el => {
+    const position = el.$type == 'bpmn:BoundaryEvent' ? grid.find(el.attachedToRef) : grid.find(el);
+    if (smallestRow === -1 || position[0] !== -1 && position[0] < smallestRow) {
+      smallestRow = position[0];
+    }
+    if (highestColumn === -1 || position[1] !== -1 && position[1] > highestColumn) {
+      highestColumn = position[1];
+    }
+  });
+  console.log([ smallestRow, highestColumn ]);
+  return [ smallestRow, highestColumn ];
+}
+
+export function findSplittingStartingPosition(grid, elements) {
+  console.log('findSplittingStartingPosition');
+
+  let smallestRow = null;
+  let smallestColumn = null;
+  elements.forEach(el => {
+    const position = el.$type == 'bpmn:BoundaryEvent' ? grid.find(el.attachedToRef) : grid.find(el);
+    if (smallestRow == null || position[0] !== -1 && position[0] < smallestRow) {
+      smallestRow = position[0];
+    }
+    if (smallestColumn == null || position[0] !== -1 && position[1] !== -1 && position[1] < smallestColumn) {
+      smallestColumn = position[1];
+    }
+  });
+  console.log([ smallestRow, smallestColumn ]);
+  return [ smallestRow, smallestColumn ];
+}


### PR DESCRIPTION
Closes #48 

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Issue 1: Multiple start events  
![image](https://github.com/user-attachments/assets/ed30e028-718c-4c10-81a4-9f0f45e67980)

Resolution: 
![image](https://github.com/user-attachments/assets/89dd6f8b-39fb-4e0a-8eee-87d46f7270d1)


Issue 2: Multiple gateway elements connected must be in single row
![image](https://github.com/user-attachments/assets/d4420985-1426-4ea2-8571-c2a9d7a0f202)

Resolution: 
![image](https://github.com/user-attachments/assets/1250b080-6efa-40c9-bcba-dd139b876392)


### Changes Implemented:

- Modified the logic to only include elements of type bpmn:StartEvent when processing starting elements.
- Added an incomingHandler to check whether an element has more than one incoming edge
-    If the element has multiple incoming edges, the handler now sends the second one to the grid below.
- Updated the handling of gateways to ensure they are displayed on a single row in the grid.

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
