### PR TITLE
Improve grid placement

### DIFF
--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -116,10 +116,10 @@ export class Grid {
     let [ row, col ] = this.find(element);
     const [ , maxCol ] = this.getGridDimensions();
 
-    if (col < maxCol) {
+    if (col < maxCol - 1) {
 
       // add element in next column
-      this.grid[row].length = maxCol + 1;
+      this.grid[row].length = maxCol;
       this.grid[row][maxCol] = element;
       this.grid[row][col] = null;
 

--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -1,3 +1,5 @@
+import { is } from './di/DiUtil.js';
+
 export class Grid {
   constructor() {
     this.grid = [];
@@ -41,7 +43,6 @@ export class Grid {
     if (!element) {
       this._addStart(newElement);
     }
-
     const [ row, col ] = this.find(element);
     this.grid[row].splice(col + 1, 0, newElement);
   }
@@ -111,6 +112,60 @@ export class Grid {
     return elements;
   }
 
+  adjustGridPosition(element) {
+    let [ row, col ] = this.find(element);
+    const [ , maxCol ] = this.getGridDimensions();
+
+    if (col < maxCol) {
+
+      // add element in next column
+      this.grid[row].length = maxCol + 1;
+      this.grid[row][maxCol] = element;
+      this.grid[row][col] = null;
+
+    }
+  }
+
+  adjustRowToStartEvent(element) {
+    let [ row, ] = this.findStartEventCoordinates();
+    let [ currentRow, currentCol ] = this.find(element);
+
+    // if element doesn't already exist in current row, add element
+    if (!this.grid[row][currentCol]) {
+      this.grid[row][currentCol] = element;
+      this.grid[currentRow][currentCol] = null;
+    }
+  }
+
+  getGridDimensions() {
+    const numRows = this.grid.length;
+    let maxCols = 0;
+
+    for (let i = 0; i < numRows; i++) {
+      const currentRowLength = this.grid[i].length;
+      if (currentRowLength > maxCols) {
+        maxCols = currentRowLength;
+      }
+    }
+
+    return [ numRows , maxCols ];
+  }
+
+  findStartEventCoordinates() {
+    for (let row = 0; row < this.grid.length; row++) {
+      for (let col = 0; col < this.grid[row].length; col++) {
+        const element = this.grid[row][col];
+
+        if (element && is(element,'bpmn:StartEvent')) {
+          return [ row, col ];
+
+        }
+      }
+    }
+    return [ null,null ];
+  }
+
+
   elementsByPosition() {
     const elements = [];
 
@@ -130,4 +185,5 @@ export class Grid {
     return elements;
   }
 }
+
 

--- a/lib/Layouter.js
+++ b/lib/Layouter.js
@@ -82,7 +82,7 @@ export class Layouter {
         this.handlePlane(currentElement);
       }
 
-      const nextElements = this.handle('addToGrid', { element: currentElement, grid, visited });
+      const nextElements = this.handle('addToGrid', { element: currentElement, grid, visited, stack });
 
       nextElements.flat().forEach(el => {
         stack.push(el);

--- a/lib/handler/incomingHandler.js
+++ b/lib/handler/incomingHandler.js
@@ -1,0 +1,20 @@
+import { is } from '../di/DiUtil.js';
+
+export default {
+  'addToGrid': ({ element, grid, visited }) => {
+    const nextElements = [];
+
+    // Handle incoming paths
+    const incoming = (element.incoming || [])
+      .map(out => out.sourceRef)
+      .filter(el => el);
+
+    // Splitting gateway would always be the same row as start event
+    if (incoming.length > 1 && is(element,'bpmn:ExclusiveGateway')) {
+      grid.adjustRowToStartEvent(element);
+
+      // TODO: see about column
+    }
+    return nextElements;
+  },
+};

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -1,5 +1,6 @@
 import { default as attacherHandler } from './attachersHandler.js';
 import { default as elementHandler } from './elementHandler.js';
 import { default as outgoingHandler } from './outgoingHandler.js';
+import { default as incomingHandler } from './incomingHandler.js';
 
-export const handlers = [ elementHandler, outgoingHandler, attacherHandler ];
+export const handlers = [ elementHandler, incomingHandler, outgoingHandler, attacherHandler ];

--- a/lib/handler/outgoingHandler.js
+++ b/lib/handler/outgoingHandler.js
@@ -1,24 +1,7 @@
 import { connectElements } from '../utils/layoutUtil.js';
 import { is } from '../di/DiUtil.js';
+import { findElementInTree } from '../utils/elementUtils.js';
 
-function sortByType(arr, type) {
-  const nonMatching = arr.filter(item => !is(item,type));
-  const matching = arr.filter(item => is(item,type));
-
-  return [ ...matching, ...nonMatching ];
-
-}
-
-function isFutureIncoming(element, visited) {
-  if (element.incoming.length > 1) {
-    for (const incomingElement of element.incoming) {
-      if (!visited.has(incomingElement.sourceRef)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
 
 export default {
   'addToGrid': ({ element, grid, visited, stack }) => {
@@ -41,7 +24,7 @@ export default {
       }
 
       // Future incoming should go in stack (if no element in stack, have to visit the current one)
-      if (stack.length > 0 && isFutureIncoming(nextElement, visited)) {
+      if (stack.length > 0 && isFutureIncoming(nextElement, visited) && !checkForLoop(nextElement, visited)) {
         return;
       }
 
@@ -86,3 +69,35 @@ export default {
 
   }
 };
+
+
+// helpers /////
+
+function sortByType(arr, type) {
+  const nonMatching = arr.filter(item => !is(item,type));
+  const matching = arr.filter(item => is(item,type));
+
+  return [ ...matching, ...nonMatching ];
+
+}
+
+function checkForLoop(element, visited) {
+  for (const incomingElement of element.incoming) {
+    if (!visited.has(incomingElement.sourceRef)) {
+
+      return findElementInTree(element, incomingElement.sourceRef);
+    }
+  }
+}
+
+
+function isFutureIncoming(element, visited) {
+  if (element.incoming.length > 1) {
+    for (const incomingElement of element.incoming) {
+      if (!visited.has(incomingElement.sourceRef)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/lib/handler/outgoingHandler.js
+++ b/lib/handler/outgoingHandler.js
@@ -1,8 +1,28 @@
 import { connectElements } from '../utils/layoutUtil.js';
+import { is } from '../di/DiUtil.js';
+
+function sortByType(arr, type) {
+  const nonMatching = arr.filter(item => !is(item,type));
+  const matching = arr.filter(item => is(item,type));
+
+  return [ ...matching, ...nonMatching ];
+
+}
+
+function isFutureIncoming(element, visited) {
+  if (element.incoming.length > 1) {
+    for (const incomingElement of element.incoming) {
+      if (!visited.has(incomingElement.sourceRef)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 export default {
-  'addToGrid': ({ element, grid, visited }) => {
-    const nextElements = [];
+  'addToGrid': ({ element, grid, visited, stack }) => {
+    let nextElements = [];
 
     // Handle outgoing paths
     const outgoing = (element.outgoing || [])
@@ -10,13 +30,27 @@ export default {
       .filter(el => el);
 
     let previousElement = null;
+
+    if (outgoing.length > 1) {
+      grid.adjustGridPosition(element);
+    }
+
     outgoing.forEach((nextElement, index, arr) => {
       if (visited.has(nextElement)) {
         return;
       }
 
+      // Future incoming should go in stack (if no element in stack, have to visit the current one)
+      if (stack.length > 0 && isFutureIncoming(nextElement, visited)) {
+        return;
+      }
+
       if (!previousElement) {
         grid.addAfter(element, nextElement);
+      }
+
+      else if (is(element, 'bpmn:ExclusiveGateway') && is(nextElement, 'bpmn:ExclusiveGateway')) {
+        grid.addAfter(previousElement, nextElement);
       }
       else {
         grid.addBelow(arr[index - 1], nextElement);
@@ -31,8 +65,11 @@ export default {
       visited.add(nextElement);
     });
 
+    // Sort elements by priority to ensure proper stack placement
+    nextElements = sortByType(nextElements, 'bpmn:ExclusiveGateway'); // TODO: sort by priority
     return nextElements;
   },
+
   'createConnectionDi': ({ element, row, col, layoutGrid, diFactory }) => {
     const outgoing = element.outgoing || [];
 

--- a/lib/handler/outgoingHandler.js
+++ b/lib/handler/outgoingHandler.js
@@ -23,8 +23,8 @@ export default {
         return;
       }
 
-      // Future incoming should go in stack (if no element in stack, have to visit the current one)
-      if (stack.length > 0 && isFutureIncoming(nextElement, visited) && !checkForLoop(nextElement, visited)) {
+      // Prevents revisiting future incoming elements and ensures proper traversal without early exit.
+      if ((previousElement || stack.length > 0) && isFutureIncoming(nextElement, visited) && !checkForLoop(nextElement, visited)) {
         return;
       }
 
@@ -84,7 +84,6 @@ function sortByType(arr, type) {
 function checkForLoop(element, visited) {
   for (const incomingElement of element.incoming) {
     if (!visited.has(incomingElement.sourceRef)) {
-
       return findElementInTree(element, incomingElement.sourceRef);
     }
   }

--- a/lib/utils/elementUtils.js
+++ b/lib/utils/elementUtils.js
@@ -5,3 +5,24 @@ export function isConnection(element) {
 export function isBoundaryEvent(element) {
   return !!element.attachedToRef;
 }
+
+export function findElementInTree(currentElement, targetElement, visited = new Set()) {
+
+  if (currentElement === targetElement) return true;
+
+  if (visited.has(currentElement)) return false;
+
+  visited.add(currentElement);
+
+  // If currentElement has no outgoing connections, return false
+  if (!currentElement.outgoing || currentElement.outgoing.length === 0) return false;
+
+  // Recursively check each outgoing element
+  for (let nextElement of currentElement.outgoing.map(out => out.targetRef)) {
+    if (findElementInTree(nextElement, targetElement, visited)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/test/fixtures/gateway-future-incoming.bpmn
+++ b/test/fixtures/gateway-future-incoming.bpmn
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_09v8hxu" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_15s0zkv" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0jex9t2</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_0i9wepe">
+      <bpmn:incoming>Flow_0jex9t2</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dkwsel</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0os3n7r</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0jex9t2" sourceRef="StartEvent_1" targetRef="Gateway_0i9wepe" />
+    <bpmn:task id="Activity_1fm0k9p">
+      <bpmn:incoming>Flow_1dkwsel</bpmn:incoming>
+      <bpmn:outgoing>Flow_1eqfyy9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1dkwsel" sourceRef="Gateway_0i9wepe" targetRef="Activity_1fm0k9p" />
+    <bpmn:task id="Activity_17so0gf">
+      <bpmn:incoming>Flow_0os3n7r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yabdi4</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0os3n7r" sourceRef="Gateway_0i9wepe" targetRef="Activity_17so0gf" />
+    <bpmn:task id="Activity_0rfkk61">
+      <bpmn:incoming>Flow_1yabdi4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1l9x7zt</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1yabdi4" sourceRef="Activity_17so0gf" targetRef="Activity_0rfkk61" />
+    <bpmn:task id="Activity_0jprkqn">
+      <bpmn:incoming>Flow_1l9x7zt</bpmn:incoming>
+      <bpmn:outgoing>Flow_085nst5</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1l9x7zt" sourceRef="Activity_0rfkk61" targetRef="Activity_0jprkqn" />
+    <bpmn:exclusiveGateway id="Gateway_0n2a4od">
+      <bpmn:incoming>Flow_085nst5</bpmn:incoming>
+      <bpmn:incoming>Flow_1eqfyy9</bpmn:incoming>
+      <bpmn:outgoing>Flow_14wnyk7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_085nst5" sourceRef="Activity_0jprkqn" targetRef="Gateway_0n2a4od" />
+    <bpmn:sequenceFlow id="Flow_1eqfyy9" sourceRef="Activity_1fm0k9p" targetRef="Gateway_0n2a4od" />
+    <bpmn:endEvent id="Event_19p8z8n">
+      <bpmn:incoming>Flow_14wnyk7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_14wnyk7" sourceRef="Gateway_0n2a4od" targetRef="Event_19p8z8n" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_15s0zkv">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0i9wepe_di" bpmnElement="Gateway_0i9wepe" isMarkerVisible="true">
+        <dc:Bounds x="245" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fm0k9p_di" bpmnElement="Activity_1fm0k9p">
+        <dc:Bounds x="360" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17so0gf_di" bpmnElement="Activity_17so0gf">
+        <dc:Bounds x="360" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rfkk61_di" bpmnElement="Activity_0rfkk61">
+        <dc:Bounds x="530" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jprkqn_di" bpmnElement="Activity_0jprkqn">
+        <dc:Bounds x="700" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0n2a4od_di" bpmnElement="Gateway_0n2a4od" isMarkerVisible="true">
+        <dc:Bounds x="875" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_19p8z8n_di" bpmnElement="Event_19p8z8n">
+        <dc:Bounds x="1002" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jex9t2_di" bpmnElement="Flow_0jex9t2">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="245" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dkwsel_di" bpmnElement="Flow_1dkwsel">
+        <di:waypoint x="295" y="120" />
+        <di:waypoint x="360" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0os3n7r_di" bpmnElement="Flow_0os3n7r">
+        <di:waypoint x="270" y="145" />
+        <di:waypoint x="270" y="230" />
+        <di:waypoint x="360" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yabdi4_di" bpmnElement="Flow_1yabdi4">
+        <di:waypoint x="460" y="230" />
+        <di:waypoint x="530" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1l9x7zt_di" bpmnElement="Flow_1l9x7zt">
+        <di:waypoint x="630" y="230" />
+        <di:waypoint x="700" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_085nst5_di" bpmnElement="Flow_085nst5">
+        <di:waypoint x="800" y="230" />
+        <di:waypoint x="900" y="230" />
+        <di:waypoint x="900" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1eqfyy9_di" bpmnElement="Flow_1eqfyy9">
+        <di:waypoint x="460" y="120" />
+        <di:waypoint x="875" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14wnyk7_di" bpmnElement="Flow_14wnyk7">
+        <di:waypoint x="925" y="120" />
+        <di:waypoint x="1002" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/multiple-event-start.bpmn
+++ b/test/fixtures/multiple-event-start.bpmn
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0cla1rn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1yz7q9f" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_06h18wl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_0ap6guu">
+      <bpmn:incoming>Flow_06h18wl</bpmn:incoming>
+      <bpmn:incoming>Flow_15h8nze</bpmn:incoming>
+      <bpmn:outgoing>Flow_08xa2up</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_06h18wl" sourceRef="StartEvent_1" targetRef="Gateway_0ap6guu" />
+    <bpmn:task id="Activity_0zv5qmi">
+      <bpmn:incoming>Flow_08xa2up</bpmn:incoming>
+      <bpmn:outgoing>Flow_02qxkun</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_08xa2up" sourceRef="Gateway_0ap6guu" targetRef="Activity_0zv5qmi" />
+    <bpmn:endEvent id="Event_1ywzid2">
+      <bpmn:incoming>Flow_02qxkun</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_02qxkun" sourceRef="Activity_0zv5qmi" targetRef="Event_1ywzid2" />
+    <bpmn:intermediateThrowEvent id="Event_0e4wk1t">
+      <bpmn:outgoing>Flow_1opxssl</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:task id="Activity_1g4jnkx">
+      <bpmn:incoming>Flow_1opxssl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1iq5j5f</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1opxssl" sourceRef="Event_0e4wk1t" targetRef="Activity_1g4jnkx" />
+    <bpmn:task id="Activity_1kjkcu7">
+      <bpmn:incoming>Flow_1iq5j5f</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qedg64</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1iq5j5f" sourceRef="Activity_1g4jnkx" targetRef="Activity_1kjkcu7" />
+    <bpmn:task id="Activity_0upyz71">
+      <bpmn:incoming>Flow_0qedg64</bpmn:incoming>
+      <bpmn:outgoing>Flow_15h8nze</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0qedg64" sourceRef="Activity_1kjkcu7" targetRef="Activity_0upyz71" />
+    <bpmn:sequenceFlow id="Flow_15h8nze" sourceRef="Activity_0upyz71" targetRef="Gateway_0ap6guu" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1yz7q9f">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="642" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ap6guu_di" bpmnElement="Gateway_0ap6guu" isMarkerVisible="true">
+        <dc:Bounds x="735" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0zv5qmi_di" bpmnElement="Activity_0zv5qmi">
+        <dc:Bounds x="850" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ywzid2_di" bpmnElement="Event_1ywzid2">
+        <dc:Bounds x="1022" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kjkcu7_di" bpmnElement="Activity_1kjkcu7">
+        <dc:Bounds x="410" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0upyz71_di" bpmnElement="Activity_0upyz71">
+        <dc:Bounds x="570" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1g4jnkx_di" bpmnElement="Activity_1g4jnkx">
+        <dc:Bounds x="240" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0e4wk1t_di" bpmnElement="Event_0e4wk1t">
+        <dc:Bounds x="152" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06h18wl_di" bpmnElement="Flow_06h18wl">
+        <di:waypoint x="678" y="120" />
+        <di:waypoint x="735" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08xa2up_di" bpmnElement="Flow_08xa2up">
+        <di:waypoint x="785" y="120" />
+        <di:waypoint x="850" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02qxkun_di" bpmnElement="Flow_02qxkun">
+        <di:waypoint x="950" y="120" />
+        <di:waypoint x="1022" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1opxssl_di" bpmnElement="Flow_1opxssl">
+        <di:waypoint x="188" y="240" />
+        <di:waypoint x="240" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15h8nze_di" bpmnElement="Flow_15h8nze">
+        <di:waypoint x="670" y="240" />
+        <di:waypoint x="760" y="240" />
+        <di:waypoint x="760" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1iq5j5f_di" bpmnElement="Flow_1iq5j5f">
+        <di:waypoint x="340" y="240" />
+        <di:waypoint x="410" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qedg64_di" bpmnElement="Flow_0qedg64">
+        <di:waypoint x="510" y="240" />
+        <di:waypoint x="570" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/multiple-gateways-complex.bpmn
+++ b/test/fixtures/multiple-gateways-complex.bpmn
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kqhcex" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1m6n614" isExecutable="true">
+    <bpmn:startEvent id="Event_1w7vipy">
+      <bpmn:outgoing>Flow_1eympa1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_1">
+      <bpmn:incoming>Flow_1eympa1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zy5kqu</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1eympa1" sourceRef="Event_1w7vipy" targetRef="Activity_1" />
+    <bpmn:exclusiveGateway id="Gateway_1">
+      <bpmn:incoming>Flow_0zy5kqu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cgbqzp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0tifn2t</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0zy5kqu" sourceRef="Activity_1" targetRef="Gateway_1" />
+    <bpmn:exclusiveGateway id="Gateway_2">
+      <bpmn:incoming>Flow_0cgbqzp</bpmn:incoming>
+      <bpmn:outgoing>Flow_09zvkbl</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1ceaqcv</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0cgbqzp" sourceRef="Gateway_1" targetRef="Gateway_2" />
+    <bpmn:task id="Activity_2">
+      <bpmn:incoming>Flow_09zvkbl</bpmn:incoming>
+      <bpmn:outgoing>Flow_0srpkls</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_09zvkbl" sourceRef="Gateway_2" targetRef="Activity_2" />
+    <bpmn:exclusiveGateway id="Gateway_3">
+      <bpmn:incoming>Flow_0srpkls</bpmn:incoming>
+      <bpmn:outgoing>Flow_02by20k</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0noq65r</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0srpkls" sourceRef="Activity_2" targetRef="Gateway_3" />
+    <bpmn:task id="Activity_3">
+      <bpmn:incoming>Flow_02by20k</bpmn:incoming>
+      <bpmn:outgoing>Flow_1o0idpq</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_02by20k" sourceRef="Gateway_3" targetRef="Activity_3" />
+    <bpmn:exclusiveGateway id="Gateway_4">
+      <bpmn:incoming>Flow_1o0idpq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yssdsf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13am6r7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1o0idpq" sourceRef="Activity_3" targetRef="Gateway_4" />
+    <bpmn:task id="Activity_4">
+      <bpmn:incoming>Flow_0yssdsf</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wkajd8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0yssdsf" sourceRef="Gateway_4" targetRef="Activity_4" />
+    <bpmn:exclusiveGateway id="Gateway_5">
+      <bpmn:incoming>Flow_1wkajd8</bpmn:incoming>
+      <bpmn:incoming>Flow_0tifn2t</bpmn:incoming>
+      <bpmn:outgoing>Flow_05k2ez6</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1wkajd8" sourceRef="Activity_4" targetRef="Gateway_5" />
+    <bpmn:task id="Activity_5">
+      <bpmn:incoming>Flow_05k2ez6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vu64s3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_05k2ez6" sourceRef="Gateway_5" targetRef="Activity_5" />
+    <bpmn:exclusiveGateway id="Gateway_6">
+      <bpmn:incoming>Flow_0vu64s3</bpmn:incoming>
+      <bpmn:incoming>Flow_1ceaqcv</bpmn:incoming>
+      <bpmn:incoming>Flow_0noq65r</bpmn:incoming>
+      <bpmn:incoming>Flow_13am6r7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vc2vjd</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0vu64s3" sourceRef="Activity_5" targetRef="Gateway_6" />
+    <bpmn:task id="Activity_6">
+      <bpmn:incoming>Flow_1vc2vjd</bpmn:incoming>
+      <bpmn:outgoing>Flow_0q7aowo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1vc2vjd" sourceRef="Gateway_6" targetRef="Activity_6" />
+    <bpmn:endEvent id="Event_1ewaat6">
+      <bpmn:incoming>Flow_0q7aowo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0q7aowo" sourceRef="Activity_6" targetRef="Event_1ewaat6" />
+    <bpmn:sequenceFlow id="Flow_0tifn2t" sourceRef="Gateway_1" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_1ceaqcv" sourceRef="Gateway_2" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_0noq65r" sourceRef="Gateway_3" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_13am6r7" sourceRef="Gateway_4" targetRef="Gateway_6" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1m6n614">
+      <bpmndi:BPMNShape id="Event_1w7vipy_di" bpmnElement="Event_1w7vipy">
+        <dc:Bounds x="179" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0oszoba_di" bpmnElement="Activity_1">
+        <dc:Bounds x="270" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ce7yak_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="425" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0pptqpo_di" bpmnElement="Gateway_2" isMarkerVisible="true">
+        <dc:Bounds x="535" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wyr78j_di" bpmnElement="Activity_2">
+        <dc:Bounds x="650" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zp4lwv_di" bpmnElement="Gateway_3" isMarkerVisible="true">
+        <dc:Bounds x="815" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vw18sg_di" bpmnElement="Activity_3">
+        <dc:Bounds x="930" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0yqjjze_di" bpmnElement="Gateway_4" isMarkerVisible="true">
+        <dc:Bounds x="1095" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1huqg5k_di" bpmnElement="Activity_4">
+        <dc:Bounds x="1210" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1an5xba_di" bpmnElement="Gateway_5" isMarkerVisible="true">
+        <dc:Bounds x="1375" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1tkjq0m_di" bpmnElement="Activity_5">
+        <dc:Bounds x="1490" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_13syuoy_di" bpmnElement="Gateway_6" isMarkerVisible="true">
+        <dc:Bounds x="1655" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s7rlxr_di" bpmnElement="Activity_6">
+        <dc:Bounds x="1770" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ewaat6_di" bpmnElement="Event_1ewaat6">
+        <dc:Bounds x="1942" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1eympa1_di" bpmnElement="Flow_1eympa1">
+        <di:waypoint x="215" y="190" />
+        <di:waypoint x="270" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zy5kqu_di" bpmnElement="Flow_0zy5kqu">
+        <di:waypoint x="370" y="190" />
+        <di:waypoint x="425" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cgbqzp_di" bpmnElement="Flow_0cgbqzp">
+        <di:waypoint x="475" y="190" />
+        <di:waypoint x="535" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09zvkbl_di" bpmnElement="Flow_09zvkbl">
+        <di:waypoint x="585" y="190" />
+        <di:waypoint x="650" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0srpkls_di" bpmnElement="Flow_0srpkls">
+        <di:waypoint x="750" y="190" />
+        <di:waypoint x="815" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02by20k_di" bpmnElement="Flow_02by20k">
+        <di:waypoint x="865" y="190" />
+        <di:waypoint x="930" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o0idpq_di" bpmnElement="Flow_1o0idpq">
+        <di:waypoint x="1030" y="190" />
+        <di:waypoint x="1095" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yssdsf_di" bpmnElement="Flow_0yssdsf">
+        <di:waypoint x="1145" y="190" />
+        <di:waypoint x="1210" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wkajd8_di" bpmnElement="Flow_1wkajd8">
+        <di:waypoint x="1310" y="190" />
+        <di:waypoint x="1375" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05k2ez6_di" bpmnElement="Flow_05k2ez6">
+        <di:waypoint x="1425" y="190" />
+        <di:waypoint x="1490" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vu64s3_di" bpmnElement="Flow_0vu64s3">
+        <di:waypoint x="1590" y="190" />
+        <di:waypoint x="1655" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vc2vjd_di" bpmnElement="Flow_1vc2vjd">
+        <di:waypoint x="1705" y="190" />
+        <di:waypoint x="1770" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q7aowo_di" bpmnElement="Flow_0q7aowo">
+        <di:waypoint x="1870" y="190" />
+        <di:waypoint x="1942" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tifn2t_di" bpmnElement="Flow_0tifn2t">
+        <di:waypoint x="450" y="165" />
+        <di:waypoint x="450" y="80" />
+        <di:waypoint x="1400" y="80" />
+        <di:waypoint x="1400" y="165" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ceaqcv_di" bpmnElement="Flow_1ceaqcv">
+        <di:waypoint x="560" y="215" />
+        <di:waypoint x="560" y="360" />
+        <di:waypoint x="1680" y="360" />
+        <di:waypoint x="1680" y="215" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0noq65r_di" bpmnElement="Flow_0noq65r">
+        <di:waypoint x="840" y="215" />
+        <di:waypoint x="840" y="350" />
+        <di:waypoint x="1680" y="350" />
+        <di:waypoint x="1680" y="215" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13am6r7_di" bpmnElement="Flow_13am6r7">
+        <di:waypoint x="1120" y="215" />
+        <di:waypoint x="1120" y="340" />
+        <di:waypoint x="1680" y="340" />
+        <di:waypoint x="1680" y="215" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/multiple-gateways-with-tasks.bpmn
+++ b/test/fixtures/multiple-gateways-with-tasks.bpmn
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1qauux4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_0q24st2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1sentxt</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_0b77539">
+      <bpmn:incoming>Flow_1sentxt</bpmn:incoming>
+      <bpmn:outgoing>Flow_1t8s8fu</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1rz4ms0</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1sentxt" sourceRef="StartEvent_1" targetRef="Gateway_0b77539" />
+    <bpmn:exclusiveGateway id="Gateway_0t1bths">
+      <bpmn:incoming>Flow_1t8s8fu</bpmn:incoming>
+      <bpmn:outgoing>Flow_19ibn4j</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1buy237</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0toqniu</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1t8s8fu" sourceRef="Gateway_0b77539" targetRef="Gateway_0t1bths" />
+    <bpmn:task id="Activity_0011ct6">
+      <bpmn:incoming>Flow_1rz4ms0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0y0i43v</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1rz4ms0" sourceRef="Gateway_0b77539" targetRef="Activity_0011ct6" />
+    <bpmn:endEvent id="Event_0vex13u">
+      <bpmn:incoming>Flow_0y0i43v</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0y0i43v" sourceRef="Activity_0011ct6" targetRef="Event_0vex13u" />
+    <bpmn:task id="Activity_1906xbc">
+      <bpmn:incoming>Flow_19ibn4j</bpmn:incoming>
+      <bpmn:outgoing>Flow_0kwut4m</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_19ibn4j" sourceRef="Gateway_0t1bths" targetRef="Activity_1906xbc" />
+    <bpmn:endEvent id="Event_15bsca2">
+      <bpmn:incoming>Flow_0kwut4m</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0kwut4m" sourceRef="Activity_1906xbc" targetRef="Event_15bsca2" />
+    <bpmn:task id="Activity_16ahi4e">
+      <bpmn:incoming>Flow_1buy237</bpmn:incoming>
+      <bpmn:outgoing>Flow_1w5zehr</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1buy237" sourceRef="Gateway_0t1bths" targetRef="Activity_16ahi4e" />
+    <bpmn:endEvent id="Event_15ch5cf">
+      <bpmn:incoming>Flow_1w5zehr</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1w5zehr" sourceRef="Activity_16ahi4e" targetRef="Event_15ch5cf" />
+    <bpmn:task id="Activity_1ngn8i4">
+      <bpmn:incoming>Flow_0toqniu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mgwyna</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0toqniu" sourceRef="Gateway_0t1bths" targetRef="Activity_1ngn8i4" />
+    <bpmn:endEvent id="Event_1jkb6nq">
+      <bpmn:incoming>Flow_0mgwyna</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0mgwyna" sourceRef="Activity_1ngn8i4" targetRef="Event_1jkb6nq" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0q24st2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0b77539_di" bpmnElement="Gateway_0b77539" isMarkerVisible="true">
+        <dc:Bounds x="245" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0t1bths_di" bpmnElement="Gateway_0t1bths" isMarkerVisible="true">
+        <dc:Bounds x="645" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0011ct6_di" bpmnElement="Activity_0011ct6">
+        <dc:Bounds x="340" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vex13u_di" bpmnElement="Event_0vex13u">
+        <dc:Bounds x="482" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1906xbc_di" bpmnElement="Activity_1906xbc">
+        <dc:Bounds x="750" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_15bsca2_di" bpmnElement="Event_15bsca2">
+        <dc:Bounds x="912" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16ahi4e_di" bpmnElement="Activity_16ahi4e">
+        <dc:Bounds x="750" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_15ch5cf_di" bpmnElement="Event_15ch5cf">
+        <dc:Bounds x="912" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ngn8i4_di" bpmnElement="Activity_1ngn8i4">
+        <dc:Bounds x="750" y="300" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1jkb6nq_di" bpmnElement="Event_1jkb6nq">
+        <dc:Bounds x="912" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1sentxt_di" bpmnElement="Flow_1sentxt">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="245" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t8s8fu_di" bpmnElement="Flow_1t8s8fu">
+        <di:waypoint x="295" y="120" />
+        <di:waypoint x="645" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rz4ms0_di" bpmnElement="Flow_1rz4ms0">
+        <di:waypoint x="270" y="145" />
+        <di:waypoint x="270" y="240" />
+        <di:waypoint x="340" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y0i43v_di" bpmnElement="Flow_0y0i43v">
+        <di:waypoint x="440" y="240" />
+        <di:waypoint x="482" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19ibn4j_di" bpmnElement="Flow_19ibn4j">
+        <di:waypoint x="695" y="120" />
+        <di:waypoint x="750" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kwut4m_di" bpmnElement="Flow_0kwut4m">
+        <di:waypoint x="850" y="120" />
+        <di:waypoint x="912" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1buy237_di" bpmnElement="Flow_1buy237">
+        <di:waypoint x="670" y="145" />
+        <di:waypoint x="670" y="230" />
+        <di:waypoint x="750" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1w5zehr_di" bpmnElement="Flow_1w5zehr">
+        <di:waypoint x="850" y="230" />
+        <di:waypoint x="912" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0toqniu_di" bpmnElement="Flow_0toqniu">
+        <di:waypoint x="670" y="145" />
+        <di:waypoint x="670" y="340" />
+        <di:waypoint x="750" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mgwyna_di" bpmnElement="Flow_0mgwyna">
+        <di:waypoint x="850" y="340" />
+        <di:waypoint x="912" y="340" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/multiple-gateways.bpmn
+++ b/test/fixtures/multiple-gateways.bpmn
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_140ofur" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1kbtdz9" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_174mdxz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_1u0gfdz">
+      <bpmn:incoming>Flow_174mdxz</bpmn:incoming>
+      <bpmn:incoming>Flow_137be2r</bpmn:incoming>
+      <bpmn:outgoing>Flow_0x21408</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_174mdxz" sourceRef="StartEvent_1" targetRef="Gateway_1u0gfdz" />
+    <bpmn:exclusiveGateway id="Gateway_0opt6rs">
+      <bpmn:incoming>Flow_0x21408</bpmn:incoming>
+      <bpmn:outgoing>Flow_1825yj3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0cwbrfm</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0x21408" sourceRef="Gateway_1u0gfdz" targetRef="Gateway_0opt6rs" />
+    <bpmn:exclusiveGateway id="Gateway_06frsfc">
+      <bpmn:incoming>Flow_1825yj3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lt2wxp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0p0ho5k</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1825yj3" sourceRef="Gateway_0opt6rs" targetRef="Gateway_06frsfc" />
+    <bpmn:task id="Activity_0qdwjpf">
+      <bpmn:incoming>Flow_0cwbrfm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1kooziw</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0cwbrfm" sourceRef="Gateway_0opt6rs" targetRef="Activity_0qdwjpf" />
+    <bpmn:endEvent id="Event_0em8oet">
+      <bpmn:incoming>Flow_1kooziw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1kooziw" sourceRef="Activity_0qdwjpf" targetRef="Event_0em8oet" />
+    <bpmn:task id="Activity_0picprh">
+      <bpmn:incoming>Flow_0lt2wxp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ge6e6x</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0lt2wxp" sourceRef="Gateway_06frsfc" targetRef="Activity_0picprh" />
+    <bpmn:endEvent id="Event_1609krb">
+      <bpmn:incoming>Flow_1ge6e6x</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ge6e6x" sourceRef="Activity_0picprh" targetRef="Event_1609krb" />
+    <bpmn:task id="Activity_1387cfu">
+      <bpmn:incoming>Flow_0p0ho5k</bpmn:incoming>
+      <bpmn:outgoing>Flow_137be2r</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0p0ho5k" sourceRef="Gateway_06frsfc" targetRef="Activity_1387cfu" />
+    <bpmn:sequenceFlow id="Flow_137be2r" sourceRef="Activity_1387cfu" targetRef="Gateway_1u0gfdz" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1kbtdz9">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1u0gfdz_di" bpmnElement="Gateway_1u0gfdz" isMarkerVisible="true">
+        <dc:Bounds x="245" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0opt6rs_di" bpmnElement="Gateway_0opt6rs" isMarkerVisible="true">
+        <dc:Bounds x="355" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_06frsfc_di" bpmnElement="Gateway_06frsfc" isMarkerVisible="true">
+        <dc:Bounds x="725" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0qdwjpf_di" bpmnElement="Activity_0qdwjpf">
+        <dc:Bounds x="440" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0em8oet_di" bpmnElement="Event_0em8oet">
+        <dc:Bounds x="582" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0picprh_di" bpmnElement="Activity_0picprh">
+        <dc:Bounds x="830" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1609krb_di" bpmnElement="Event_1609krb">
+        <dc:Bounds x="992" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1387cfu_di" bpmnElement="Activity_1387cfu">
+        <dc:Bounds x="830" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_174mdxz_di" bpmnElement="Flow_174mdxz">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="245" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x21408_di" bpmnElement="Flow_0x21408">
+        <di:waypoint x="295" y="120" />
+        <di:waypoint x="355" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1825yj3_di" bpmnElement="Flow_1825yj3">
+        <di:waypoint x="405" y="120" />
+        <di:waypoint x="725" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cwbrfm_di" bpmnElement="Flow_0cwbrfm">
+        <di:waypoint x="380" y="145" />
+        <di:waypoint x="380" y="240" />
+        <di:waypoint x="440" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kooziw_di" bpmnElement="Flow_1kooziw">
+        <di:waypoint x="540" y="240" />
+        <di:waypoint x="582" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lt2wxp_di" bpmnElement="Flow_0lt2wxp">
+        <di:waypoint x="775" y="120" />
+        <di:waypoint x="830" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ge6e6x_di" bpmnElement="Flow_1ge6e6x">
+        <di:waypoint x="930" y="120" />
+        <di:waypoint x="992" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p0ho5k_di" bpmnElement="Flow_0p0ho5k">
+        <di:waypoint x="750" y="145" />
+        <di:waypoint x="750" y="230" />
+        <di:waypoint x="830" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_137be2r_di" bpmnElement="Flow_137be2r">
+        <di:waypoint x="930" y="230" />
+        <di:waypoint x="1000" y="230" />
+        <di:waypoint x="1000" y="390" />
+        <di:waypoint x="270" y="390" />
+        <di:waypoint x="270" y="145" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Closes #48 , #49 , #50 
### Proposed Changes

 - Handled future incoming: Elements can only be visited until all the incoming elements have been visited. If some element has incoming from future, do nothing and wait for element to reappear in future. 
 - When multiple incoming/outgoing to an element, adjust its position in the grid. Handled in `incomingHandler` and `outgoingHandler`
 - Stack can now hold elements sort by type, e.g, if there are two elements, Task and ExclusiveGateway. First we'll configure Task and then gateways.
 - Added integration test cases
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
