### PR TITLE
test: only indicate error on actual mismatch

### DIFF
--- a/test/template.html
+++ b/test/template.html
@@ -49,10 +49,13 @@
         display: none;
       }
 
-      .sub-container.error {
+      .sub-container.message {
         display: flex;
         justify-content: center;
         align-items: center;
+      }
+
+      .sub-container.error {
         background-color: rgba(255, 0, 0, 0.25);
         color: #F00;
       }
@@ -597,36 +600,12 @@
           }
         });
 
-        diagramViewer.importXML(diagram).then(({ warnings }) => {
-          if (warnings.length) {
-            console.warn(warnings);
-          }
-
-          diagramViewer.get('canvas').zoom('fit-viewport');
-        }).catch(err => {
-          console.error(err);
-
-          subContainerDiagram.classList.add('error');
-
-          subContainerDiagram.textContent = `Error: ${err.message}`;
-        });
-
         const diagramSnapshotViewer = new BpmnJS({
           container: subContainerSnapshot,
           bpmnRenderer: {
             defaultStrokeColor: 'red'
           }
         });
-
-        if (diagramSnapshot && diagramSnapshotMatching === false) {
-          diagramSnapshotViewer.importXML(diagramSnapshot).then(({ warnings }) => {
-            if (warnings.length) {
-              console.warn(warnings);
-            }
-
-            diagramSnapshotViewer.get('canvas').zoom('fit-viewport');
-          });
-        }
 
         const diagramOutputViewer = new BpmnJS({
           container: subContainerOutput,
@@ -635,23 +614,57 @@
           }
         });
 
-        diagramOutputViewer.importXML(diagramOutput).then(({ warnings }) => {
-          if (warnings.length) {
-            console.warn(warnings);
+        const errors = Promise.all([
+          diagramViewer.importXML(diagram).then(({ warnings }) => {
+            if (warnings.length) {
+              console.warn(warnings);
+            }
+
+            diagramViewer.get('canvas').zoom('fit-viewport');
+          }).catch(err => {
+            console.error('Viewer render error', err);
+
+            subContainerDiagram.textContent = `Error: ${err.message}`;
+            subContainerDiagram.classList.add('message');
+
+            return err;
+          }),
+
+          diagramOutputViewer.importXML(diagramOutput).then(({ warnings }) => {
+            if (warnings.length) {
+              console.warn(warnings);
+            }
+
+            diagramOutputViewer.get('canvas').zoom('fit-viewport');
+
+            if (diagramSnapshot) {
+              diagramSnapshotViewer.get('canvas').viewbox(diagramOutputViewer.get('canvas').viewbox());
+            }
+          }).catch(err => {
+            console.error('Output render error', err);
+
+            subContainerOutput.textContent = `Error: ${err.message}`;
+            subContainerOutput.classList.add('message');
+          })
+        ]);
+
+        if (diagramSnapshot && diagramSnapshotMatching === false) {
+          diagramSnapshotViewer.importXML(diagramSnapshot).then(({ warnings }) => {
+            if (warnings.length) {
+              console.warn(warnings);
+            }
+
+            diagramSnapshotViewer.get('canvas').zoom('fit-viewport');
+          }).catch(err => {
+            console.error('Snapshot render error', err);
+          });
+        }
+
+        errors.then(([ a, b ]) => {
+          if (a && b && a.message !== b.message) {
+            subContainerOutput.classList.add('error');
           }
-
-          diagramOutputViewer.get('canvas').zoom('fit-viewport');
-
-          if (diagramSnapshot) {
-            diagramSnapshotViewer.get('canvas').viewbox(diagramOutputViewer.get('canvas').viewbox());
-          }
-        }).catch(err => {
-          console.error(err);
-
-          subContainerOutput.classList.add('error');
-
-          subContainerOutput.textContent = `Error: ${err.message}`;
-        });;
+        });
 
         let isSyncing = false;
 


### PR DESCRIPTION
### Proposed Changes

![image](https://github.com/user-attachments/assets/c0d4bed2-d0e4-4bbf-9da2-80db7d7394fb)

Before this change we'd indicate an (expected) import error as a bug.

Now we only indicate an error where expected does not match actual error.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
