### PR TITLE
fix: happy path is interrupted by misplaced splitting gateway. Closes #78

### DIFF
--- a/lib/Grid.js
+++ b/lib/Grid.js
@@ -125,20 +125,14 @@ export class Grid {
   }
 
   adjustRowForMultipleIncoming(elements, currentElement) {
-    const results = elements.map(element => this.find(element));
 
     // filter only rows that currently exist, excluding any future or non-existent rows
-    const lowestRow = Math.min(...results
-      .map(result => result[0])
-      .filter(row => row >= 0));
+    const lowestRow = this.getLowestRow(elements);
 
     const [ row , col ] = this.find(currentElement);
 
-    // if element doesn't already exist in current row, add element
-    if (lowestRow < row && !this.grid[lowestRow][col]) {
-      this.grid[lowestRow][col] = currentElement;
-      this.grid[row][col] = null;
-    }
+    this.grid[lowestRow][col] = currentElement;
+    this.grid[row][col] = null;
   }
 
   adjustColumnForMultipleIncoming(elements, currentElement) {
@@ -211,5 +205,31 @@ export class Grid {
     const flattenedGrid = this.grid.flat();
     const uniqueElements = new Set(flattenedGrid.filter(value => value));
     return uniqueElements.size;
+  }
+
+  shrink() {
+    this.grid = this.grid.filter(row => !row.every(col => ((col == null))));
+  }
+
+  getLowestRow(elements) {
+    const results = elements.map(element => this.find(element));
+
+    // filter only rows that currently exist, excluding any future or non-existent rows
+    return Math.min(...results
+      .map(result => result[0])
+      .filter(row => row >= 0));
+  }
+
+  getLowestCol(elements) {
+    const results = elements.map(element => this.find(element));
+
+    return Math.min(...results
+      .map(result => result[1])
+      .filter(col => col >= 0));
+  }
+
+  removeElementAt(position) {
+    const [ row, col ] = position;
+    this.grid[row][col] = null;
   }
 }

--- a/lib/handler/incomingHandler.js
+++ b/lib/handler/incomingHandler.js
@@ -1,3 +1,5 @@
+import { is } from '../di/DiUtil.js';
+
 export default {
   'addToGrid': ({ element, grid, visited }) => {
     const nextElements = [];
@@ -9,8 +11,29 @@ export default {
     // adjust the row if it is empty
     if (incoming.length > 1) {
       grid.adjustColumnForMultipleIncoming(incoming, element);
-      grid.adjustRowForMultipleIncoming(incoming, element);
+
+      const lowestRow = grid.getLowestRow(incoming);
+      const lowestCol = grid.getLowestCol(incoming);
+      const [ row , col ] = grid.find(element);
+
+      if (lowestRow < row && !grid.get(lowestRow, col)) {
+        if ((isNextElementExclusiveGateway(incoming) && is(element, 'bpmn:ExclusiveGateway'))) {
+
+          // move ExclusiveGateway under the next column of the left element
+          if (!grid.get(row, lowestCol + 1)) {
+            grid.add(element, [ row, lowestCol + 1 ]);
+            grid.removeElementAt([ row, col ]);
+          }
+        } else {
+          grid.adjustRowForMultipleIncoming(incoming, element);
+        }
+      }
+      grid.shrink();
     }
     return nextElements;
   },
 };
+
+function isNextElementExclusiveGateway(elements) {
+  return elements.every(element => is(element, 'bpmn:ExclusiveGateway'));
+}

--- a/lib/handler/outgoingHandler.js
+++ b/lib/handler/outgoingHandler.js
@@ -33,7 +33,7 @@ export default {
       }
 
       else if (is(element, 'bpmn:ExclusiveGateway') && is(nextElement, 'bpmn:ExclusiveGateway')) {
-        grid.addAfter(previousElement, nextElement);
+        grid.addBelow(previousElement, nextElement);
       }
       else {
         grid.addBelow(arr[index - 1], nextElement);

--- a/test/fixtures/scenario.multiple-task-gateways-columns-2.bpmn
+++ b/test/fixtures/scenario.multiple-task-gateways-columns-2.bpmn
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1trge93" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="Process_147rph1" isExecutable="true">
+    <bpmn:startEvent id="Event_1i7iwe0" name="0_Event_1i7iwe0">
+      <bpmn:outgoing>Flow_1vm93wu</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_15c2lag" name="6_Activity_15c2lag">
+      <bpmn:incoming>Flow_1m5409c</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rb8ovc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_037fh1c" name="9_Event_037fh1c">
+      <bpmn:incoming>Flow_1swal9t</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_0zdascr" name="3_Activity_0zdascr">
+      <bpmn:incoming>Flow_1yn8g32</bpmn:incoming>
+      <bpmn:outgoing>Flow_1g45ev9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1swal9t" sourceRef="Gateway_0q66rqp" targetRef="Event_037fh1c" />
+    <bpmn:sequenceFlow id="Flow_0rb8ovc" sourceRef="Activity_15c2lag" targetRef="Gateway_1xwnjq4" />
+    <bpmn:sequenceFlow id="Flow_1g45ev9" sourceRef="Activity_0zdascr" targetRef="Gateway_1y4khn9" />
+    <bpmn:sequenceFlow id="Flow_0u8xfq7" sourceRef="Gateway_1xwnjq4" targetRef="Gateway_0q66rqp" />
+    <bpmn:sequenceFlow id="Flow_13tfz28" sourceRef="Gateway_1y4khn9" targetRef="Gateway_0q66rqp" />
+    <bpmn:sequenceFlow id="Flow_1uz5qcm" sourceRef="Gateway_1xwnjq4" targetRef="Gateway_1dmgdzy" />
+    <bpmn:sequenceFlow id="Flow_1im8bre" sourceRef="Gateway_1y4khn9" targetRef="Gateway_0tmpxz4" />
+    <bpmn:sequenceFlow id="Flow_1yn8g32" sourceRef="Gateway_1dmgdzy" targetRef="Activity_0zdascr" />
+    <bpmn:sequenceFlow id="Flow_1m5409c" sourceRef="Gateway_0tmpxz4" targetRef="Activity_15c2lag" />
+    <bpmn:sequenceFlow id="Flow_1gpu0bj" sourceRef="Gateway_1wbvtl4" targetRef="Gateway_1dmgdzy" />
+    <bpmn:sequenceFlow id="Flow_14hlia1" sourceRef="Gateway_1wbvtl4" targetRef="Gateway_0tmpxz4" />
+    <bpmn:sequenceFlow id="Flow_1vm93wu" sourceRef="Event_1i7iwe0" targetRef="Gateway_1wbvtl4" />
+    <bpmn:exclusiveGateway id="Gateway_0q66rqp" name="8_Gateway_0q66rqp">
+      <bpmn:incoming>Flow_13tfz28</bpmn:incoming>
+      <bpmn:incoming>Flow_0u8xfq7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1swal9t</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_1y4khn9" name="4_Gateway_1y4khn9">
+      <bpmn:incoming>Flow_1g45ev9</bpmn:incoming>
+      <bpmn:outgoing>Flow_1im8bre</bpmn:outgoing>
+      <bpmn:outgoing>Flow_13tfz28</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_1xwnjq4" name="7_Gateway_1xwnjq4">
+      <bpmn:incoming>Flow_0rb8ovc</bpmn:incoming>
+      <bpmn:outgoing>Flow_1uz5qcm</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0u8xfq7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_0tmpxz4" name="2_2_Gateway_0tmpxz4">
+      <bpmn:incoming>Flow_1im8bre</bpmn:incoming>
+      <bpmn:incoming>Flow_14hlia1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1m5409c</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_1dmgdzy" name="2_1_Gateway_1dmgdzy">
+      <bpmn:incoming>Flow_1gpu0bj</bpmn:incoming>
+      <bpmn:incoming>Flow_1uz5qcm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yn8g32</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_1wbvtl4" name="1_Gateway_1wbvtl4">
+      <bpmn:incoming>Flow_1vm93wu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gpu0bj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14hlia1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_147rph1">
+      <bpmndi:BPMNShape id="Event_1i7iwe0_di" bpmnElement="Event_1i7iwe0">
+        <dc:Bounds x="192" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="145" width="84" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1wbvtl4_di" bpmnElement="Gateway_1wbvtl4" isMarkerVisible="true">
+        <dc:Bounds x="285" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="267" y="65" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tmpxz4_di" bpmnElement="Gateway_0tmpxz4" isMarkerVisible="true">
+        <dc:Bounds x="395" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="378" y="152" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15c2lag_di" bpmnElement="Activity_15c2lag">
+        <dc:Bounds x="510" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1xwnjq4_di" bpmnElement="Gateway_1xwnjq4" isMarkerVisible="true">
+        <dc:Bounds x="675" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="656" y="152" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0q66rqp_di" bpmnElement="Gateway_0q66rqp" isMarkerVisible="true">
+        <dc:Bounds x="795" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="777" y="65" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_037fh1c_di" bpmnElement="Event_037fh1c">
+        <dc:Bounds x="922" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="897" y="145" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02lch1k" bpmnElement="Gateway_1dmgdzy" isMarkerVisible="true">
+        <dc:Bounds x="395" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="380" y="322" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02rdlex" bpmnElement="Activity_0zdascr">
+        <dc:Bounds x="510" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0o4io2s" bpmnElement="Gateway_1y4khn9" isMarkerVisible="true">
+        <dc:Bounds x="675" y="265" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="658" y="322" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1vm93wu_di" bpmnElement="Flow_1vm93wu">
+        <di:waypoint x="228" y="120" />
+        <di:waypoint x="285" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14hlia1_di" bpmnElement="Flow_14hlia1">
+        <di:waypoint x="335" y="120" />
+        <di:waypoint x="395" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1m5409c_di" bpmnElement="Flow_1m5409c">
+        <di:waypoint x="445" y="120" />
+        <di:waypoint x="510" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rb8ovc_di" bpmnElement="Flow_0rb8ovc">
+        <di:waypoint x="610" y="120" />
+        <di:waypoint x="675" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u8xfq7_di" bpmnElement="Flow_0u8xfq7">
+        <di:waypoint x="725" y="120" />
+        <di:waypoint x="795" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1swal9t_di" bpmnElement="Flow_1swal9t">
+        <di:waypoint x="845" y="120" />
+        <di:waypoint x="922" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0ejog6j" bpmnElement="Flow_1yn8g32">
+        <di:waypoint x="445" y="290" />
+        <di:waypoint x="510" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_03l1nax" bpmnElement="Flow_1g45ev9">
+        <di:waypoint x="610" y="290" />
+        <di:waypoint x="675" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gpu0bj_di" bpmnElement="Flow_1gpu0bj">
+        <di:waypoint x="310" y="145" />
+        <di:waypoint x="310" y="290" />
+        <di:waypoint x="395" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13tfz28_di" bpmnElement="Flow_13tfz28">
+        <di:waypoint x="725" y="290" />
+        <di:waypoint x="820" y="290" />
+        <di:waypoint x="820" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1im8bre_di" bpmnElement="Flow_1im8bre">
+        <di:waypoint x="684" y="281" />
+        <di:waypoint x="435" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uz5qcm_di" bpmnElement="Flow_1uz5qcm">
+        <di:waypoint x="684" y="129" />
+        <di:waypoint x="435" y="280" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/scenario.second-splitting-gateway.bpmn
+++ b/test/fixtures/scenario.second-splitting-gateway.bpmn
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vdt762" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.22.0">
+  <bpmn:process id="Process_1upcc55" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_04db176</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_0v554u5">
+      <bpmn:incoming>Flow_04db176</bpmn:incoming>
+      <bpmn:outgoing>Flow_1cg5arr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1sjcbpe</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_04db176" sourceRef="StartEvent_1" targetRef="Gateway_0v554u5" />
+    <bpmn:task id="Activity_1bfapau">
+      <bpmn:incoming>Flow_1cg5arr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bo9fsz</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1cg5arr" sourceRef="Gateway_0v554u5" targetRef="Activity_1bfapau" />
+    <bpmn:task id="Activity_0y9lfy6">
+      <bpmn:incoming>Flow_0bo9fsz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jqpx6a</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0bo9fsz" sourceRef="Activity_1bfapau" targetRef="Activity_0y9lfy6" />
+    <bpmn:task id="Activity_0s5li4m">
+      <bpmn:incoming>Flow_1jqpx6a</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wa57yc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1jqpx6a" sourceRef="Activity_0y9lfy6" targetRef="Activity_0s5li4m" />
+    <bpmn:exclusiveGateway id="Gateway_0abyzys">
+      <bpmn:incoming>Flow_0wa57yc</bpmn:incoming>
+      <bpmn:incoming>Flow_049i3lu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1127x4i</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0wa57yc" sourceRef="Activity_0s5li4m" targetRef="Gateway_0abyzys" />
+    <bpmn:endEvent id="Event_0c0hq0d">
+      <bpmn:incoming>Flow_1127x4i</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1127x4i" sourceRef="Gateway_0abyzys" targetRef="Event_0c0hq0d" />
+    <bpmn:exclusiveGateway id="Gateway_1epltn6">
+      <bpmn:incoming>Flow_1sjcbpe</bpmn:incoming>
+      <bpmn:outgoing>Flow_0p70o41</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0soei6r</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1sjcbpe" sourceRef="Gateway_0v554u5" targetRef="Gateway_1epltn6" />
+    <bpmn:task id="Activity_1kvk3tl">
+      <bpmn:incoming>Flow_0p70o41</bpmn:incoming>
+      <bpmn:outgoing>Flow_0phw8s0</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0p70o41" sourceRef="Gateway_1epltn6" targetRef="Activity_1kvk3tl" />
+    <bpmn:exclusiveGateway id="Gateway_1sizo9j">
+      <bpmn:incoming>Flow_0phw8s0</bpmn:incoming>
+      <bpmn:incoming>Flow_0soei6r</bpmn:incoming>
+      <bpmn:outgoing>Flow_049i3lu</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0phw8s0" sourceRef="Activity_1kvk3tl" targetRef="Gateway_1sizo9j" />
+    <bpmn:sequenceFlow id="Flow_049i3lu" sourceRef="Gateway_1sizo9j" targetRef="Gateway_0abyzys" />
+    <bpmn:sequenceFlow id="Flow_0soei6r" sourceRef="Gateway_1epltn6" targetRef="Gateway_1sizo9j" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1upcc55">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0v554u5_di" bpmnElement="Gateway_0v554u5" isMarkerVisible="true">
+        <dc:Bounds x="275" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bfapau_di" bpmnElement="Activity_1bfapau">
+        <dc:Bounds x="390" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y9lfy6_di" bpmnElement="Activity_0y9lfy6">
+        <dc:Bounds x="560" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5li4m_di" bpmnElement="Activity_0s5li4m">
+        <dc:Bounds x="730" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0abyzys_di" bpmnElement="Gateway_0abyzys" isMarkerVisible="true">
+        <dc:Bounds x="905" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c0hq0d_di" bpmnElement="Event_0c0hq0d">
+        <dc:Bounds x="1032" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1epltn6_di" bpmnElement="Gateway_1epltn6" isMarkerVisible="true">
+        <dc:Bounds x="395" y="205" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kvk3tl_di" bpmnElement="Activity_1kvk3tl">
+        <dc:Bounds x="520" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1sizo9j_di" bpmnElement="Gateway_1sizo9j" isMarkerVisible="true">
+        <dc:Bounds x="695" y="205" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_04db176_di" bpmnElement="Flow_04db176">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="275" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cg5arr_di" bpmnElement="Flow_1cg5arr">
+        <di:waypoint x="325" y="120" />
+        <di:waypoint x="390" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bo9fsz_di" bpmnElement="Flow_0bo9fsz">
+        <di:waypoint x="490" y="120" />
+        <di:waypoint x="560" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jqpx6a_di" bpmnElement="Flow_1jqpx6a">
+        <di:waypoint x="660" y="120" />
+        <di:waypoint x="730" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wa57yc_di" bpmnElement="Flow_0wa57yc">
+        <di:waypoint x="830" y="120" />
+        <di:waypoint x="905" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1127x4i_di" bpmnElement="Flow_1127x4i">
+        <di:waypoint x="955" y="120" />
+        <di:waypoint x="1032" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sjcbpe_di" bpmnElement="Flow_1sjcbpe">
+        <di:waypoint x="300" y="145" />
+        <di:waypoint x="300" y="230" />
+        <di:waypoint x="395" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p70o41_di" bpmnElement="Flow_0p70o41">
+        <di:waypoint x="445" y="230" />
+        <di:waypoint x="520" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0phw8s0_di" bpmnElement="Flow_0phw8s0">
+        <di:waypoint x="620" y="230" />
+        <di:waypoint x="695" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_049i3lu_di" bpmnElement="Flow_049i3lu">
+        <di:waypoint x="745" y="230" />
+        <di:waypoint x="930" y="230" />
+        <di:waypoint x="930" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0soei6r_di" bpmnElement="Flow_0soei6r">
+        <di:waypoint x="420" y="255" />
+        <di:waypoint x="420" y="360" />
+        <di:waypoint x="720" y="360" />
+        <di:waypoint x="720" y="255" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/snapshots/scenario.second-splitting-gateway.bpmn
+++ b/test/snapshots/scenario.second-splitting-gateway.bpmn
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1vdt762" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.22.0">
+  <bpmn:process id="Process_1upcc55" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_04db176</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_0v554u5">
+      <bpmn:incoming>Flow_04db176</bpmn:incoming>
+      <bpmn:outgoing>Flow_1cg5arr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1sjcbpe</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_04db176" sourceRef="StartEvent_1" targetRef="Gateway_0v554u5" />
+    <bpmn:task id="Activity_1bfapau">
+      <bpmn:incoming>Flow_1cg5arr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bo9fsz</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1cg5arr" sourceRef="Gateway_0v554u5" targetRef="Activity_1bfapau" />
+    <bpmn:task id="Activity_0y9lfy6">
+      <bpmn:incoming>Flow_0bo9fsz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jqpx6a</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0bo9fsz" sourceRef="Activity_1bfapau" targetRef="Activity_0y9lfy6" />
+    <bpmn:task id="Activity_0s5li4m">
+      <bpmn:incoming>Flow_1jqpx6a</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wa57yc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1jqpx6a" sourceRef="Activity_0y9lfy6" targetRef="Activity_0s5li4m" />
+    <bpmn:exclusiveGateway id="Gateway_0abyzys">
+      <bpmn:incoming>Flow_0wa57yc</bpmn:incoming>
+      <bpmn:incoming>Flow_049i3lu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1127x4i</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0wa57yc" sourceRef="Activity_0s5li4m" targetRef="Gateway_0abyzys" />
+    <bpmn:endEvent id="Event_0c0hq0d">
+      <bpmn:incoming>Flow_1127x4i</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1127x4i" sourceRef="Gateway_0abyzys" targetRef="Event_0c0hq0d" />
+    <bpmn:exclusiveGateway id="Gateway_1epltn6">
+      <bpmn:incoming>Flow_1sjcbpe</bpmn:incoming>
+      <bpmn:outgoing>Flow_0p70o41</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0soei6r</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1sjcbpe" sourceRef="Gateway_0v554u5" targetRef="Gateway_1epltn6" />
+    <bpmn:task id="Activity_1kvk3tl">
+      <bpmn:incoming>Flow_0p70o41</bpmn:incoming>
+      <bpmn:outgoing>Flow_0phw8s0</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0p70o41" sourceRef="Gateway_1epltn6" targetRef="Activity_1kvk3tl" />
+    <bpmn:exclusiveGateway id="Gateway_1sizo9j">
+      <bpmn:incoming>Flow_0phw8s0</bpmn:incoming>
+      <bpmn:incoming>Flow_0soei6r</bpmn:incoming>
+      <bpmn:outgoing>Flow_049i3lu</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0phw8s0" sourceRef="Activity_1kvk3tl" targetRef="Gateway_1sizo9j" />
+    <bpmn:sequenceFlow id="Flow_049i3lu" sourceRef="Gateway_1sizo9j" targetRef="Gateway_0abyzys" />
+    <bpmn:sequenceFlow id="Flow_0soei6r" sourceRef="Gateway_1epltn6" targetRef="Gateway_1sizo9j" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1upcc55">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1upcc55" bpmnElement="Process_1upcc55">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0v554u5_di" bpmnElement="Gateway_0v554u5" isMarkerVisible="true">
+        <dc:Bounds x="200" y="45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bfapau_di" bpmnElement="Activity_1bfapau">
+        <dc:Bounds x="325" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y9lfy6_di" bpmnElement="Activity_0y9lfy6">
+        <dc:Bounds x="475" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5li4m_di" bpmnElement="Activity_0s5li4m">
+        <dc:Bounds x="625" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0abyzys_di" bpmnElement="Gateway_0abyzys" isMarkerVisible="true">
+        <dc:Bounds x="800" y="45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c0hq0d_di" bpmnElement="Event_0c0hq0d">
+        <dc:Bounds x="957" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1epltn6_di" bpmnElement="Gateway_1epltn6" isMarkerVisible="true">
+        <dc:Bounds x="350" y="185" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kvk3tl_di" bpmnElement="Activity_1kvk3tl">
+        <dc:Bounds x="475" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1sizo9j_di" bpmnElement="Gateway_1sizo9j" isMarkerVisible="true">
+        <dc:Bounds x="650" y="185" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_04db176_di" bpmnElement="Flow_04db176">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="200" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cg5arr_di" bpmnElement="Flow_1cg5arr">
+        <di:waypoint x="250" y="70" />
+        <di:waypoint x="325" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sjcbpe_di" bpmnElement="Flow_1sjcbpe">
+        <di:waypoint x="225" y="95" />
+        <di:waypoint x="225" y="210" />
+        <di:waypoint x="350" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bo9fsz_di" bpmnElement="Flow_0bo9fsz">
+        <di:waypoint x="425" y="70" />
+        <di:waypoint x="475" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jqpx6a_di" bpmnElement="Flow_1jqpx6a">
+        <di:waypoint x="575" y="70" />
+        <di:waypoint x="625" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wa57yc_di" bpmnElement="Flow_0wa57yc">
+        <di:waypoint x="725" y="70" />
+        <di:waypoint x="800" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1127x4i_di" bpmnElement="Flow_1127x4i">
+        <di:waypoint x="850" y="70" />
+        <di:waypoint x="957" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p70o41_di" bpmnElement="Flow_0p70o41">
+        <di:waypoint x="400" y="210" />
+        <di:waypoint x="475" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0soei6r_di" bpmnElement="Flow_0soei6r">
+        <di:waypoint x="375" y="235" />
+        <di:waypoint x="375" y="280" />
+        <di:waypoint x="675" y="280" />
+        <di:waypoint x="675" y="235" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0phw8s0_di" bpmnElement="Flow_0phw8s0">
+        <di:waypoint x="575" y="210" />
+        <di:waypoint x="650" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_049i3lu_di" bpmnElement="Flow_049i3lu">
+        <di:waypoint x="700" y="210" />
+        <di:waypoint x="825" y="210" />
+        <di:waypoint x="825" y="95" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Closes #78
 - add utility methods to Grid.js
   - getLowestRow(elements)
   - getLowestCol(elements)
   - removeElementAt(position)
   - shrink()
 - change handlers logic for:
   - incommingHandler.js
   - outgoingHandler.js
 - add two tests:
   - scenario.multiple-task-gateways-columns-2.bpmn (it's my painfull problem :) )
   - scenario.second-splitting-gateway.bpmn (it's [issue #78](https://github.com/bpmn-io/bpmn-auto-layout/issues/78) )

### Proposed Changes
[issue #78](https://github.com/bpmn-io/bpmn-auto-layout/issues/78)

**before**
![image](https://github.com/user-attachments/assets/eaaba0c6-4bde-46c4-9996-0bd880994cff)

**after**
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/187d12bd-746f-4069-9fd5-d1211ffdb735" />
### Checklist

To ensure you provided everything we need to look at your PR:

* [+] **Brief textual description** of the changes present
* [+] **Visual demo** attached
* [] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [+] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
