### PR TITLE
fix: Partial Closes #79

### DIFF
--- a/lib/handler/attachersHandler.js
+++ b/lib/handler/attachersHandler.js
@@ -25,6 +25,7 @@ export default {
       // Add below and to the right of the element
       insertIntoGrid(nextElement, element, grid);
       nextElements.push(nextElement);
+      visited.add(nextElement);
     });
 
     return nextElements;

--- a/test/fixtures/scenario.merging-two-boundary-events.bpmn
+++ b/test/fixtures/scenario.merging-two-boundary-events.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1v58cvv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.22.0">
+  <bpmn:process id="Process_1j22wzf" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_16hudxc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0vitm4u">
+      <bpmn:incoming>Flow_16hudxc</bpmn:incoming>
+      <bpmn:outgoing>Flow_10icyr3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_16hudxc" sourceRef="StartEvent_1" targetRef="Activity_0vitm4u" />
+    <bpmn:endEvent id="Event_0xfirme">
+      <bpmn:incoming>Flow_10icyr3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_10icyr3" sourceRef="Activity_0vitm4u" targetRef="Event_0xfirme" />
+    <bpmn:boundaryEvent id="Event_10yvr22" attachedToRef="Activity_0vitm4u">
+      <bpmn:outgoing>Flow_1ibn7a6</bpmn:outgoing>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_05vxnp9" attachedToRef="Activity_0vitm4u">
+      <bpmn:outgoing>Flow_127b6w9</bpmn:outgoing>
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_1q9jwcw">
+      <bpmn:incoming>Flow_1ibn7a6</bpmn:incoming>
+      <bpmn:incoming>Flow_127b6w9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ibn7a6" sourceRef="Event_10yvr22" targetRef="Event_1q9jwcw" />
+    <bpmn:sequenceFlow id="Flow_127b6w9" sourceRef="Event_05vxnp9" targetRef="Event_1q9jwcw" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1j22wzf">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vitm4u_di" bpmnElement="Activity_0vitm4u">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xfirme_di" bpmnElement="Event_0xfirme">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q9jwcw_di" bpmnElement="Event_1q9jwcw">
+        <dc:Bounds x="422" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05ew43y_di" bpmnElement="Event_10yvr22">
+        <dc:Bounds x="272" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tlafy6_di" bpmnElement="Event_05vxnp9">
+        <dc:Bounds x="332" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_16hudxc_di" bpmnElement="Flow_16hudxc">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10icyr3_di" bpmnElement="Flow_10icyr3">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ibn7a6_di" bpmnElement="Flow_1ibn7a6">
+        <di:waypoint x="290" y="178" />
+        <di:waypoint x="290" y="240" />
+        <di:waypoint x="422" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_127b6w9_di" bpmnElement="Flow_127b6w9">
+        <di:waypoint x="350" y="178" />
+        <di:waypoint x="350" y="240" />
+        <di:waypoint x="422" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/snapshots/scenario.merging-two-boundary-events.bpmn
+++ b/test/snapshots/scenario.merging-two-boundary-events.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1v58cvv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.22.0">
+  <bpmn:process id="Process_1j22wzf" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_16hudxc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0vitm4u">
+      <bpmn:incoming>Flow_16hudxc</bpmn:incoming>
+      <bpmn:outgoing>Flow_10icyr3</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_16hudxc" sourceRef="StartEvent_1" targetRef="Activity_0vitm4u" />
+    <bpmn:endEvent id="Event_0xfirme">
+      <bpmn:incoming>Flow_10icyr3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_10icyr3" sourceRef="Activity_0vitm4u" targetRef="Event_0xfirme" />
+    <bpmn:boundaryEvent id="Event_10yvr22" attachedToRef="Activity_0vitm4u">
+      <bpmn:outgoing>Flow_1ibn7a6</bpmn:outgoing>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_05vxnp9" attachedToRef="Activity_0vitm4u">
+      <bpmn:outgoing>Flow_127b6w9</bpmn:outgoing>
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_1q9jwcw">
+      <bpmn:incoming>Flow_1ibn7a6</bpmn:incoming>
+      <bpmn:incoming>Flow_127b6w9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ibn7a6" sourceRef="Event_10yvr22" targetRef="Event_1q9jwcw" />
+    <bpmn:sequenceFlow id="Flow_127b6w9" sourceRef="Event_05vxnp9" targetRef="Event_1q9jwcw" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1j22wzf">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1j22wzf" bpmnElement="Process_1j22wzf">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vitm4u_di" bpmnElement="Activity_0vitm4u">
+        <dc:Bounds x="175" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10yvr22_di" bpmnElement="Event_10yvr22">
+        <dc:Bounds x="190.33333333333334" y="92" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05vxnp9_di" bpmnElement="Event_05vxnp9">
+        <dc:Bounds x="223.66666666666669" y="92" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xfirme_di" bpmnElement="Event_0xfirme">
+        <dc:Bounds x="357" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q9jwcw_di" bpmnElement="Event_1q9jwcw">
+        <dc:Bounds x="357" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_16hudxc_di" bpmnElement="Flow_16hudxc">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10icyr3_di" bpmnElement="Flow_10icyr3">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="357" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ibn7a6_di" bpmnElement="Flow_1ibn7a6">
+        <di:waypoint x="208.33333333333334" y="128" />
+        <di:waypoint x="208.33333333333334" y="210" />
+        <di:waypoint x="357" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_127b6w9_di" bpmnElement="Flow_127b6w9">
+        <di:waypoint x="241.66666666666669" y="128" />
+        <di:waypoint x="241.66666666666669" y="210" />
+        <di:waypoint x="357" y="210" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
### Proposed Changes

Partial fix for [issue #79](https://github.com/bpmn-io/bpmn-auto-layout/issues/79)

**as is**
![image](https://github.com/user-attachments/assets/d87257e5-29f2-46eb-a193-6e3427a35a68)

**to be**
<img width="392" alt="image" src="https://github.com/user-attachments/assets/71712535-f1c8-4c53-8ce6-8aa51ecfe7d6" />


That could be better... but I haven't a lot of time to fix 'createElementDi' in attachersHandler.js.
It is necessary to increase the distance between attachers for 100% fix.
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/b05e56dc-18f6-48bf-9cc8-6ee17e90a8c3" />

But this is already much better than it was and closes a couple more cases. :)

### Checklist

To ensure you provided everything we need to look at your PR:

* [+] **Brief textual description** of the changes present
* [+] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [+] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
