### PR TITLE
Layout of loops improved. Depending on y coords of source/target, mak…

### DIFF
--- a/lib/utils/layoutUtil.js
+++ b/lib/utils/layoutUtil.js
@@ -83,6 +83,7 @@ export function connectElements(source, target, layoutGrid) {
 
     let bendY;
     if (sourceMid.y >= targetMid.y) {
+
       // edge goes below
       bendY = sourceMid.y + offsetY;
 
@@ -92,8 +93,8 @@ export function connectElements(source, target, layoutGrid) {
         { x: targetMid.x, y: bendY },
         getDockingPoint(targetMid, targetBounds, 'b')
       ];
-    }
-    else {
+    } else {
+
       // edge goes above
       bendY = sourceMid.y - offsetY;
 

--- a/lib/utils/layoutUtil.js
+++ b/lib/utils/layoutUtil.js
@@ -77,6 +77,35 @@ export function connectElements(source, target, layoutGrid) {
     ];
   }
 
+  // negative dX indicates connection from future to past
+  if (dX < 0) {
+    const offsetY = DEFAULT_CELL_HEIGHT / 2;
+
+    let bendY;
+    if (sourceMid.y >= targetMid.y) {
+      // edge goes below
+      bendY = sourceMid.y + offsetY;
+
+      return [
+        getDockingPoint(sourceMid, sourceBounds, 'b'),
+        { x: sourceMid.x, y: bendY },
+        { x: targetMid.x, y: bendY },
+        getDockingPoint(targetMid, targetBounds, 'b')
+      ];
+    }
+    else {
+      // edge goes above
+      bendY = sourceMid.y - offsetY;
+
+      return [
+        getDockingPoint(sourceMid, sourceBounds, 't'),
+        { x: sourceMid.x, y: bendY },
+        { x: targetMid.x, y: bendY },
+        getDockingPoint(targetMid, targetBounds, 't')
+      ];
+    }
+  }
+
   // connect horizontally
   if (dY === 0) {
     if (isDirectPathBlocked(source, target, layoutGrid)) {
@@ -120,15 +149,6 @@ export function connectElements(source, target, layoutGrid) {
     }
   }
 
-  // negative dX indicates connection from future to past
-  if (dX < 0 && dY <= 0) {
-    return [
-      getDockingPoint(sourceMid, sourceBounds, 'b'),
-      { x: sourceMid.x, y: sourceMid.y + DEFAULT_CELL_HEIGHT / 2 },
-      { x: targetMid.x, y: sourceMid.y + DEFAULT_CELL_HEIGHT / 2 },
-      getDockingPoint(targetMid, targetBounds, 'b')
-    ];
-  }
   const directManhattan = directManhattanConnect(source, target, layoutGrid);
 
   if (directManhattan) {

--- a/test/fixtures/scenario.gateway-with-loop-back.bpmn
+++ b/test/fixtures/scenario.gateway-with-loop-back.bpmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_7s6e1cgyp" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_s2hspl2jk" name="Default Process" isExecutable="false">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_aiso836wm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_s226az8gc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="A" name="A">
+      <bpmn:incoming>Flow_aiso836wm</bpmn:incoming>
+      <bpmn:incoming>Flow_1o32dscvy</bpmn:incoming>
+      <bpmn:outgoing>Flow_cuz0x09vh</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="GW" default="Flow_1o32dscvy">
+      <bpmn:incoming>Flow_cuz0x09vh</bpmn:incoming>
+      <bpmn:outgoing>Flow_l65bcwkx0</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1o32dscvy</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="B" name="B">
+      <bpmn:incoming>Flow_l65bcwkx0</bpmn:incoming>
+      <bpmn:outgoing>Flow_s226az8gc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_aiso836wm" sourceRef="start" targetRef="A" />
+    <bpmn:sequenceFlow id="Flow_cuz0x09vh" sourceRef="A" targetRef="GW" />
+    <bpmn:sequenceFlow id="Flow_l65bcwkx0" sourceRef="GW" targetRef="B" />
+    <bpmn:sequenceFlow id="Flow_1o32dscvy" sourceRef="GW" targetRef="A" />
+    <bpmn:sequenceFlow id="Flow_s226az8gc" sourceRef="B" targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_s2hspl2jk">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_s2hspl2jk" bpmnElement="Process_s2hspl2jk">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end">
+        <dc:Bounds x="657" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="A_di" bpmnElement="A">
+        <dc:Bounds x="175" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="GW_di" bpmnElement="GW" isMarkerVisible="true">
+        <dc:Bounds x="350" y="45" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="330" y="7.5" width="89" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="B_di" bpmnElement="B">
+        <dc:Bounds x="475" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_aiso836wm_di" bpmnElement="Flow_aiso836wm">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_cuz0x09vh_di" bpmnElement="Flow_cuz0x09vh">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="350" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_l65bcwkx0_di" bpmnElement="Flow_l65bcwkx0">
+        <di:waypoint x="400" y="70" />
+        <di:waypoint x="475" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o32dscvy_di" bpmnElement="Flow_1o32dscvy">
+        <di:waypoint x="375" y="95" />
+        <di:waypoint x="375" y="190" />
+        <di:waypoint x="225" y="190" />
+        <di:waypoint x="225" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_s226az8gc_di" bpmnElement="Flow_s226az8gc">
+        <di:waypoint x="575" y="70" />
+        <di:waypoint x="657" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/snapshots/boundary-event.back-loop.bpmn
+++ b/test/snapshots/boundary-event.back-loop.bpmn
@@ -43,10 +43,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0dimcke_di" bpmnElement="SequenceFlow_0dimcke">
         <di:waypoint x="375" y="128" />
-        <di:waypoint x="375" y="140" />
-        <di:waypoint x="450" y="140" />
-        <di:waypoint x="450" y="70" />
-        <di:waypoint x="250" y="70" />
+        <di:waypoint x="375" y="180" />
+        <di:waypoint x="225" y="180" />
+        <di:waypoint x="225" y="95" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/snapshots/scenario.disconnected-loop.bpmn
+++ b/test/snapshots/scenario.disconnected-loop.bpmn
@@ -29,8 +29,10 @@
         <di:waypoint x="175" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_128ka86_di" bpmnElement="Flow_128ka86">
-        <di:waypoint x="175" y="210" />
-        <di:waypoint x="100" y="210" />
+        <di:waypoint x="225" y="250" />
+        <di:waypoint x="225" y="280" />
+        <di:waypoint x="75" y="280" />
+        <di:waypoint x="75" y="235" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/snapshots/scenario.gateway-with-loop-back.bpmn
+++ b/test/snapshots/scenario.gateway-with-loop-back.bpmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_7s6e1cgyp" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_s2hspl2jk" name="Default Process" isExecutable="false">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_aiso836wm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_s226az8gc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="A" name="A">
+      <bpmn:incoming>Flow_aiso836wm</bpmn:incoming>
+      <bpmn:incoming>Flow_1o32dscvy</bpmn:incoming>
+      <bpmn:outgoing>Flow_cuz0x09vh</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="GW" default="Flow_1o32dscvy">
+      <bpmn:incoming>Flow_cuz0x09vh</bpmn:incoming>
+      <bpmn:outgoing>Flow_l65bcwkx0</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1o32dscvy</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="B" name="B">
+      <bpmn:incoming>Flow_l65bcwkx0</bpmn:incoming>
+      <bpmn:outgoing>Flow_s226az8gc</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_aiso836wm" sourceRef="start" targetRef="A" />
+    <bpmn:sequenceFlow id="Flow_cuz0x09vh" sourceRef="A" targetRef="GW" />
+    <bpmn:sequenceFlow id="Flow_l65bcwkx0" sourceRef="GW" targetRef="B" />
+    <bpmn:sequenceFlow id="Flow_1o32dscvy" sourceRef="GW" targetRef="A" />
+    <bpmn:sequenceFlow id="Flow_s226az8gc" sourceRef="B" targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_s2hspl2jk">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_s2hspl2jk" bpmnElement="Process_s2hspl2jk">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="A_di" bpmnElement="A">
+        <dc:Bounds x="175" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="GW_di" bpmnElement="GW" isMarkerVisible="true">
+        <dc:Bounds x="350" y="45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="B_di" bpmnElement="B">
+        <dc:Bounds x="475" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end">
+        <dc:Bounds x="657" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_aiso836wm_di" bpmnElement="Flow_aiso836wm">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_cuz0x09vh_di" bpmnElement="Flow_cuz0x09vh">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="350" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_l65bcwkx0_di" bpmnElement="Flow_l65bcwkx0">
+        <di:waypoint x="400" y="70" />
+        <di:waypoint x="475" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o32dscvy_di" bpmnElement="Flow_1o32dscvy">
+        <di:waypoint x="375" y="95" />
+        <di:waypoint x="375" y="140" />
+        <di:waypoint x="225" y="140" />
+        <di:waypoint x="225" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_s226az8gc_di" bpmnElement="Flow_s226az8gc">
+        <di:waypoint x="575" y="70" />
+        <di:waypoint x="657" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Proposed fix for https://github.com/bpmn-io/bpmn-auto-layout/issues/94

### Proposed Changes

Edges that are looping back are now placed above or below instead of going straight back which causes issues if there is already a forward edge.
Had to fix snapshots of two tests which have backward edges. In my perspective, the layout improved for those two as well.
Also added test for my specific scenario.

