### PR TITLE
Add html lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,19 @@
 import { defineConfig } from 'eslint/config';
 
 import bpmnIoPlugin from 'eslint-plugin-bpmn-io';
+import html from "@html-eslint/eslint-plugin";
 
 export default defineConfig([
   {
     ignores: [ 'node_modules/**/*', 'dist/**/*', 'example/dist/**/*' ],
+  },
+  {
+    ...html.configs["flat/recommended"],
+    files: ["**/*.html"],
+    rules: {
+      ...html.configs["flat/recommended"].rules, // Must be defined. If not, all recommended rules will be lost
+      "@html-eslint/indent": ["error", 2],
+    },
   },
   ...bpmnIoPlugin.configs.browser.map(config => {
     return {

--- a/example/src/index.html
+++ b/example/src/index.html
@@ -1,16 +1,21 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Demo | bpmn-auto-layout</title>
     <meta name="description" content="Generate graphical information for your BPMN diagrams, or fix up ugly BPMN diagrams">
     <meta property="og:url" content="https://bpmn-io.github.io/bpmn-auto-layout/">
     <meta property="og:type" content="website">
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
   </head>
 
   <body>
     <div class="links top-links">
-      <a href="https://github.com/bpmn-io/bpmn-auto-layout" class="link" target="_blank" rel="noopener">View on GitHub</a>
+      <a
+        href="https://github.com/bpmn-io/bpmn-auto-layout"
+        class="link"
+        target="_blank"
+        rel="noopener"
+      >View on GitHub</a>
     </div>
     <div id="modeler">
       <h2>Input Diagram</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "min-dash": "^4.1.1"
       },
       "devDependencies": {
+        "@html-eslint/eslint-plugin": "^0.41.0",
+        "@html-eslint/parser": "^0.41.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "cross-env": "^7.0.3",
         "eslint": "^9.27.0",
@@ -1897,6 +1899,49 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@html-eslint/eslint-plugin": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.41.0.tgz",
+      "integrity": "sha512-kZhOdLOx5xGogw9CE/uGKkoo8t7fNK9PxU6kosIvu9Yveir3r2VhGYC4II/2OEGQ+O4cPk2LxV1fCpYt7XFMtQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/plugin-kit": "^0.3.1",
+        "@html-eslint/parser": "^0.41.0",
+        "@html-eslint/template-parser": "^0.41.0",
+        "@html-eslint/template-syntax-parser": "^0.41.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@html-eslint/parser": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.41.0.tgz",
+      "integrity": "sha512-QQJeq2G11T/SGYcG09+XOajm+X8XX6bVVSouB3SVlGmm3exvJis0B6tBnb+5Rz2kC/q3C21z1ZuCc/AXcFKzIA==",
+      "dev": true,
+      "dependencies": {
+        "@html-eslint/template-syntax-parser": "^0.41.0",
+        "es-html-parser": "0.2.0"
+      }
+    },
+    "node_modules/@html-eslint/template-parser": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.41.0.tgz",
+      "integrity": "sha512-ntZNMh+G13lPvwSSkr2U0XqWWDFLSZPeidcztgVCjxthwgSMdefL4au/YicnlB+h1WNBw8Pk0bAjczJXEbp85g==",
+      "dev": true,
+      "dependencies": {
+        "es-html-parser": "0.2.0"
+      }
+    },
+    "node_modules/@html-eslint/template-syntax-parser": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.41.0.tgz",
+      "integrity": "sha512-dgiE30uXWCoD89chi6KdjYOF+143bImJ3GNl3j2iy6/ZM8enTqCQVHZ48+Esf6Tx2rLBBBdxx4Rb0fG11myHsw==",
+      "dev": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -4455,6 +4500,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-html-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.2.0.tgz",
+      "integrity": "sha512-snJ7uJC8Dkx/yT0eYZrWcY57rkPU6Zui6YphPynw8r52AWf57gjqMC0GWe7OxSDipwXowFpa3rqckEeAPTOz7w==",
+      "dev": true
     },
     "node_modules/es-iterator-helpers": {
       "version": "1.2.1",
@@ -11894,6 +11945,43 @@
         "levn": "^0.4.1"
       }
     },
+    "@html-eslint/eslint-plugin": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.41.0.tgz",
+      "integrity": "sha512-kZhOdLOx5xGogw9CE/uGKkoo8t7fNK9PxU6kosIvu9Yveir3r2VhGYC4II/2OEGQ+O4cPk2LxV1fCpYt7XFMtQ==",
+      "dev": true,
+      "requires": {
+        "@eslint/plugin-kit": "^0.3.1",
+        "@html-eslint/parser": "^0.41.0",
+        "@html-eslint/template-parser": "^0.41.0",
+        "@html-eslint/template-syntax-parser": "^0.41.0"
+      }
+    },
+    "@html-eslint/parser": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.41.0.tgz",
+      "integrity": "sha512-QQJeq2G11T/SGYcG09+XOajm+X8XX6bVVSouB3SVlGmm3exvJis0B6tBnb+5Rz2kC/q3C21z1ZuCc/AXcFKzIA==",
+      "dev": true,
+      "requires": {
+        "@html-eslint/template-syntax-parser": "^0.41.0",
+        "es-html-parser": "0.2.0"
+      }
+    },
+    "@html-eslint/template-parser": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.41.0.tgz",
+      "integrity": "sha512-ntZNMh+G13lPvwSSkr2U0XqWWDFLSZPeidcztgVCjxthwgSMdefL4au/YicnlB+h1WNBw8Pk0bAjczJXEbp85g==",
+      "dev": true,
+      "requires": {
+        "es-html-parser": "0.2.0"
+      }
+    },
+    "@html-eslint/template-syntax-parser": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.41.0.tgz",
+      "integrity": "sha512-dgiE30uXWCoD89chi6KdjYOF+143bImJ3GNl3j2iy6/ZM8enTqCQVHZ48+Esf6Tx2rLBBBdxx4Rb0fG11myHsw==",
+      "dev": true
+    },
     "@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -13790,6 +13878,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
+    },
+    "es-html-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.2.0.tgz",
+      "integrity": "sha512-snJ7uJC8Dkx/yT0eYZrWcY57rkPU6Zui6YphPynw8r52AWf57gjqMC0GWe7OxSDipwXowFpa3rqckEeAPTOz7w==",
       "dev": true
     },
     "es-iterator-helpers": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "min-dash": "^4.1.1"
   },
   "devDependencies": {
+    "@html-eslint/eslint-plugin": "^0.41.0",
+    "@html-eslint/parser": "^0.41.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^9.27.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "plugin:bpmn-io/mocha",
-  "parserOptions": {
-    "ecmaVersion": 2023
-  }
-}

--- a/test/template.html
+++ b/test/template.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
   <head>
     <title>bpmn-auto-layout - Visual Test</title>
     <style>


### PR DESCRIPTION
### Proposed Changes Closes #106 

Add @html-eslint/eslint-plugin
[ESLint can now lint HTML using the html-eslint language plugin](https://eslint.org/blog/2025/05/eslint-html-plugin/)
Improves readability of code.

![image](https://github.com/user-attachments/assets/e594f5c4-7b2a-4a51-9503-405dbf8c6ddc)


### Checklist

To ensure you provided everything we need to look at your PR:

* ✅  **Brief textual description** of the changes present
* ✅ **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* ✅ Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

