### PR TITLE
feat: update package configuration for UMD and IIFE formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2989,7 +2988,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3024,7 +3022,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3551,7 +3548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4481,7 +4477,6 @@
       "integrity": "sha512-9FRoItWkrZnGalrqs0ekwS9wSuHQI2dzO+kJyHKa1hhMJPMBGrjR/cg0XMTpaLo2Vu9/gKL1o19P3sN4/YmIAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",
@@ -4958,7 +4953,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7849,7 +7843,6 @@
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.0.0.tgz",
       "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "min-dash": "^5.0.0"
       }
@@ -8527,7 +8520,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -9104,7 +9096,6 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9281,7 +9272,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10374,8 +10364,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -10721,7 +10710,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10771,7 +10759,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,12 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./umd": "./dist/bpmn-auto-layout.umd.js",
-    "./iife": "./dist/bpmn-auto-layout.iife.js"
+    "./umd": {
+      "browser": "./dist/bpmn-auto-layout.umd.js"
+    },
+    "./iife": {
+      "browser": "./dist/bpmn-auto-layout.iife.js"
+    }
   },
   "umd:main": "dist/bpmn-auto-layout.umd.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    }
+    },
+    "./umd": "./dist/bpmn-auto-layout.umd.js",
+    "./iife": "./dist/bpmn-auto-layout.iife.js"
   },
+  "umd:main": "dist/bpmn-auto-layout.umd.js",
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,25 +3,51 @@ import resolve from '@rollup/plugin-node-resolve';
 import fs from 'fs';
 const pkg = importPkg();
 
-export default {
-  input: 'lib/index.js',
-  output: [
-    {
+export default [
+  {
+    input: 'lib/index.js',
+    output: [
+      {
+        sourcemap: true,
+        format: 'esm',
+        file: pkg.exports['.'].import,
+      },
+      {
+        sourcemap: true,
+        format: 'cjs',
+        file: pkg.exports['.'].require,
+      }
+    ],
+    external: Object.keys(pkg.dependencies),
+    plugins: [
+      resolve()
+    ]
+  },
+  {
+    input: 'lib/index.js',
+    output: {
       sourcemap: true,
-      format: 'esm',
-      file: pkg.exports['.'].import,
+      format: 'umd',
+      name: 'BpmnAutoLayout',
+      file: 'dist/bpmn-auto-layout.umd.js',
     },
-    {
+    plugins: [
+      resolve()
+    ]
+  },
+  {
+    input: 'lib/index.js',
+    output: {
       sourcemap: true,
-      format: 'cjs',
-      file: pkg.exports['.'].require,
-    }
-  ],
-  external: Object.keys(pkg.dependencies),
-  plugins: [
-    resolve()
-  ]
-};
+      format: 'iife',
+      name: 'bpmnAutoLayout',
+      file: 'dist/bpmn-auto-layout.iife.js',
+    },
+    plugins: [
+      resolve()
+    ]
+  }
+];
 
 function importPkg() {
   return JSON.parse(fs.readFileSync('./package.json', { encoding: 'utf8' }));


### PR DESCRIPTION
### Proposed Changes

Issue: https://github.com/bpmn-io/bpmn-auto-layout/issues/138

Currently, `bpmn-auto-layout` only ships ESM and CJS outputs, both of which require a bundler or Node.js environment. There is no way to drop the library into a plain HTML page via a `<script>` tag.

This PR adds two standalone browser bundles to the npm package output:

- **`dist/bpmn-auto-layout.umd.js`** — UMD format, compatible with AMD loaders, CommonJS `require()`, and browser globals (`window.BpmnAutoLayout`)
- **`dist/bpmn-auto-layout.iife.js`** — IIFE format for direct `<script>` tag inclusion (`window.bpmnAutoLayout`)

Both bundles have all dependencies inlined so no separate install step is required.

Usage example:
```html
<script src="bpmn-auto-layout.iife.js"></script>
<script>
  bpmnAutoLayout.layoutProcess(xml).then(({ xml: layoutedXml }) => {
    console.log(layoutedXml);
  });
</script>
```

The existing ESM/CJS outputs are unchanged. Two new subpaths are added to the
package's `exports` map (`./umd` and `./iife`) so bundlers can reference the
standalone files explicitly, but these are purely additive and do not affect
existing imports.


No Screenshot of usage this is a DEVX only change.
