### PR TITLE
docs: clarify stable (1.x) vs next (2.0) layoutProcess return shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ console.warn(warnings);
 `LayoutWarning` instances. Invalid or unsupported input rejects with an exported
 `LayoutError`.
 
+> [!NOTE]
+> The `{ xml, warnings }` return shape, the `LayoutWarning`/`LayoutError`
+> exports and the command line below are part of the upcoming `2.0` line,
+> currently published under the `next` dist-tag (`npm install bpmn-auto-layout@next`).
+> The current stable release (`latest`, `1.x`) resolves `layoutProcess` with
+> the layouted **XML string** directly:
+>
+> ```javascript
+> // bpmn-auto-layout@latest (1.x)
+> const diagramWithLayoutXML = await layoutProcess(diagramXML);
+> ```
+>
+> If you consume the default `npm install bpmn-auto-layout`, use the `1.x`
+> form above; the `{ xml, warnings }` destructuring and the CLI require
+> `2.0` (`@next`).
+
 ## Command line
 
 The package also provides a command-line interface:


### PR DESCRIPTION
### What

The README documents the `2.0` API — `layoutProcess` resolving with `{ xml, warnings }`, the `LayoutWarning`/`LayoutError` exports, and the CLI. That version is currently published only under the `next` dist-tag (`2.0.0-alpha.2`).

A reader who follows the documented `npm install bpmn-auto-layout` gets `latest` (**1.3.0**), where `layoutProcess` resolves with the layouted **XML string** directly. So the documented destructuring:

```js
const { xml, warnings } = await layoutProcess(diagramXML); // xml === undefined on 1.x
```

silently yields `undefined` on the version `npm install` actually installs.

### Change

A small `> [!NOTE]` after the usage example distinguishing the two lines:
- **stable (`latest`, 1.x)** → `layoutProcess` resolves with the XML **string**;
- **next (`@next`, 2.0)** → `{ xml, warnings }` + `LayoutWarning`/`LayoutError` + CLI.

No code changes; docs only. This unblocks consumers on either line without pre-empting the 2.0 release (the main example stays as the 2.0 shape).

### Context

Found while wrapping `layoutProcess` to generate DI for code-first BPMN in another project — our call site had to normalize both return shapes across versions, which surfaced the doc/stable-release mismatch.